### PR TITLE
feat: add package registry hosts to proxy bypass list

### DIFF
--- a/container/network-proxy.ts
+++ b/container/network-proxy.ts
@@ -38,7 +38,15 @@ interface StrictPolicy {
 }
 
 // Non-provider-specific bypass hosts always allowed through the proxy
-const BASE_BYPASS_HOSTS = ["host.containers.internal", "http-intake.logs.us5.datadoghq.com", "registry.npmjs.org"];
+const BASE_BYPASS_HOSTS = [
+  "host.containers.internal",
+  "http-intake.logs.us5.datadoghq.com",
+  "registry.npmjs.org",
+  "pypi.org",
+  "files.pythonhosted.org",
+  "crates.io",
+  "static.crates.io",
+];
 
 // Provider-specific bypass hosts come from PROXY_BYPASS_HOSTS env var (comma-separated)
 // e.g. "api.anthropic.com,statsig.anthropic.com" for Claude


### PR DESCRIPTION
## Summary

- Add `pypi.org`, `files.pythonhosted.org`, `crates.io`, `static.crates.io` to `BASE_BYPASS_HOSTS` in `network-proxy.ts` alongside the existing `registry.npmjs.org`

## Why

MCP servers commonly install packages at startup via `pip`, `cargo`, or `bunx`. Under strict network policy, all outbound traffic is redirected through the MITM proxy. Without these entries in the bypass list, package installs fail silently and the MCP server never starts — surfacing as a "tool not available" error in the agent.

`registry.npmjs.org` was already present for npm/bunx. This extends the same treatment to Python and Rust package registries.

## Test plan

- [x] Build proxy image: `bun run build:images`
- [x] Run a strict-policy task with an MCP server that uses `pip install` or `cargo` at startup — confirm it starts successfully
- [x] Verify existing `network-proxy-test.sh` passes