### PR TITLE
fix: Node 22 proxy support, /tmp exec, log monitor false positives

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,7 +1,7 @@
 # Pin base image by digest to prevent supply chain attacks
 # To update: fetch the manifest list digest (works on all platforms):
-#   curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:oven/bun:pull" | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])" | xargs -I{} curl -sI -H "Authorization: Bearer {}" -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" "https://registry-1.docker.io/v2/oven/bun/manifests/1.2-alpine" | grep docker-content-digest
-FROM docker.io/oven/bun:1.2-alpine@sha256:0841c588f6304300baf1d395ae339ce09a6e18c4b6a7cdd4fddcbdb87a2f096a
+#   curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:oven/bun:pull" | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])" | xargs -I{} curl -sI -H "Authorization: Bearer {}" -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" "https://registry-1.docker.io/v2/oven/bun/manifests/1.3-alpine" | grep docker-content-digest
+FROM docker.io/oven/bun:1.3-alpine@sha256:32f1fcccb1523960b254c4f80973bee1a910d60be000a45c20c9129a1efcffee
 
 # Install minimal tools needed by Claude CLI and git operations
 # openssl for CA cert generation, iptables for OCI hook network enforcement

--- a/container/sandbox-run.sh
+++ b/container/sandbox-run.sh
@@ -100,7 +100,7 @@ PROXY_ENV_FLAGS=""
 if [ "$NETWORK_POLICY" = "strict" ] || [ "$NETWORK_POLICY" = "custom" ]; then
   NETWORK_FLAGS="--annotation network_policy=$NETWORK_POLICY"
   PROXY_URL="http://${TASK_ID}:x@host.containers.internal:3128"
-  PROXY_ENV_FLAGS="-e HTTP_PROXY=$PROXY_URL -e HTTPS_PROXY=$PROXY_URL -e http_proxy=$PROXY_URL -e https_proxy=$PROXY_URL"
+  PROXY_ENV_FLAGS="-e HTTP_PROXY=$PROXY_URL -e HTTPS_PROXY=$PROXY_URL -e http_proxy=$PROXY_URL -e https_proxy=$PROXY_URL -e NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/ysa-proxy-ca.crt -e NODE_USE_ENV_PROXY=1"
   if [ -n "${NO_PROXY:-}" ]; then
     PROXY_ENV_FLAGS="$PROXY_ENV_FLAGS -e NO_PROXY=$NO_PROXY -e no_proxy=$NO_PROXY"
   fi
@@ -157,11 +157,11 @@ if [ -n "${LOG_FILE:-}" ]; then
     INITIAL_LINES=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
   fi
   # Configurable log patterns — override via env to support different providers
-  MAX_TURNS_PATTERN="${MAX_TURNS_GREP_PATTERN:-error_max_turns}"
+  MAX_TURNS_PATTERN="${MAX_TURNS_GREP_PATTERN:-^{.*\"subtype\":\"error_max_turns\"}"
   if [ -n "${RESULT_GREP_PATTERN:-}" ]; then
     RESULT_PATTERN="$RESULT_GREP_PATTERN"
   else
-    RESULT_PATTERN='"type":"result"'
+    RESULT_PATTERN='^{"type":"result"'
   fi
   (
     while true; do
@@ -216,7 +216,7 @@ podman run --rm \
   --security-opt mask=/proc/timer_list \
   --security-opt mask=/proc/sched_debug \
   --read-only \
-  --tmpfs /tmp:rw,noexec,nosuid,size=256m \
+  --tmpfs /tmp:rw,nosuid,size=256m \
   --tmpfs /dev/shm:rw,nosuid,nodev,noexec,size=64m \
   --memory 4g \
   --pids-limit 512 \


### PR DESCRIPTION
## Summary

- Bump base image to `bun:1.3-alpine` (Alpine 3.22, Node 22.22.0) — enables `NODE_USE_ENV_PROXY=1` natively, making Node's built-in fetch route through the MITM proxy without any patching
- Add `NODE_EXTRA_CA_CERTS` and `NODE_USE_ENV_PROXY=1` to strict/custom proxy env flags so Node processes trust the proxy CA and respect the proxy
- Remove `noexec` from `/tmp` tmpfs — `bunx` extracts MCP server packages to `/tmp/bunx-*` at startup; `noexec` was preventing execution, causing MCP servers to fail with `status: "failed"`
- Anchor log monitor grep patterns to start of line (`^`) — prevents false positive container kills when the agent reads source files that happen to contain the monitored strings (`error_max_turns`, `"type":"result"`)

## Test plan

- [ ] Run a task with `network_policy=strict` and a GitHub/GitLab MCP server configured — MCP server should connect successfully
- [ ] Verify the agent can read files containing `error_max_turns` or `"type":"result"` without the container being killed mid-run
- [ ] Verify the container is still stopped correctly when the agent produces an actual result event