### PR TITLE
feat: show tool output in expanded log entries

### DIFF
--- a/src/api/tasks.ts
+++ b/src/api/tasks.ts
@@ -6,6 +6,23 @@ import { readFile, stat, appendFile } from "fs/promises";
 import { join } from "path";
 import { getProvider } from "../providers";
 import type { ParsedLogEntry } from "../types";
+
+function mergeToolOutputs(entries: ParsedLogEntry[]): ParsedLogEntry[] {
+  const outputMap = new Map<string, string>();
+  for (const e of entries) {
+    if (e.type === "raw" && e.icon === "tool_result" && e.tool_use_id) {
+      outputMap.set(e.tool_use_id, e.text);
+    }
+  }
+  return entries
+    .filter((e) => !(e.type === "raw" && e.icon === "tool_result"))
+    .map((e) => {
+      if (e.type === "tool_call" && e.tool_use_id && outputMap.has(e.tool_use_id)) {
+        return { ...e, output: outputMap.get(e.tool_use_id) };
+      }
+      return e;
+    });
+}
 import { getServerConfig } from "./config-store";
 
 async function fileExists(path: string): Promise<boolean> {
@@ -169,7 +186,8 @@ export const tasksRouter = router({
         }
       }
 
-      if (input.tail) return entries.slice(-input.tail);
-      return entries;
+      const merged = mergeToolOutputs(entries);
+      if (input.tail) return merged.slice(-input.tail);
+      return merged;
     }),
 });

--- a/src/dashboard/TaskDetail.tsx
+++ b/src/dashboard/TaskDetail.tsx
@@ -9,6 +9,7 @@ interface LogEntry {
   icon?: string;
   text: string;
   tool?: string;
+  output?: string;
   ts?: number;
 }
 
@@ -376,8 +377,8 @@ function LogRow({ entry, index, expanded, onToggle, isLast, progressActive }: { 
         </button>
         {expanded && (
           <div className="mx-3 mb-1.5 bg-bg-inset border border-border-subtle rounded overflow-hidden">
-            <pre className="text-[11px] font-mono text-text-muted whitespace-pre-wrap break-all leading-relaxed p-2.5 max-h-32 overflow-y-auto">
-              {entry.text}
+            <pre className="text-[11px] font-mono text-text-muted whitespace-pre-wrap break-all leading-relaxed p-2.5 max-h-64 overflow-y-auto">
+              {entry.output ?? entry.text}
             </pre>
           </div>
         )}

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -261,7 +261,26 @@ function parseClaudeLogLine(rawLine: string): ParsedLogEntry | null {
           icon: "tool",
           tool: block.name,
           text: detail,
+          tool_use_id: block.id,
         };
+      }
+    }
+  }
+
+  if (obj.type === "user" && obj.message?.content) {
+    for (const block of obj.message.content) {
+      if (block.type === "tool_result" && block.tool_use_id) {
+        let content = "";
+        if (typeof block.content === "string") {
+          content = block.content;
+        } else if (Array.isArray(block.content)) {
+          content = block.content
+            .filter((b: any) => b.type === "text")
+            .map((b: any) => b.text)
+            .join("\n");
+        }
+        if (content.length > 10000) content = "…" + content.slice(-10000);
+        return { type: "raw", icon: "tool_result", text: content, tool_use_id: block.tool_use_id };
       }
     }
   }

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -3,6 +3,8 @@ export interface ParsedLogEntry {
   icon?: string;
   text: string;
   tool?: string;
+  tool_use_id?: string;
+  output?: string;
   session_id?: string;
   cost?: number;
   turns?: number;


### PR DESCRIPTION
## Summary

- Parse `tool_result` user messages from Claude stream-json output
- Emit intermediate entries with the tool output content, keyed by `tool_use_id`
- Post-process log entries to attach output to matching `tool_call` entries and drop the intermediates
- Truncate output at 10,000 chars (keeping the tail, most useful for errors)
- Expanding a Bash/Read/Write/etc. log row now shows the actual command output instead of just the command string

## Test plan

- [x] Run a task with Bash commands — expand a log entry and verify stdout/stderr is shown
- [x] Verify long outputs are truncated with leading `…`
- [x] Verify tool_call entries without a result (still running) still show the command as before