### PR TITLE
fix: restrict proxy bypass to specific server port

### DIFF
--- a/container/network-proxy.ts
+++ b/container/network-proxy.ts
@@ -37,16 +37,32 @@ interface StrictPolicy {
   scopedAllowRules: ScopedAllowRule[]; // MCP tool hosts — allow all methods for specific project paths
 }
 
-// Non-provider-specific bypass hosts always allowed through the proxy
+// Non-provider-specific bypass hosts always allowed through the proxy.
+// Entries may be "host" or "host:port" — port-qualified entries only match that specific port.
 const BASE_BYPASS_HOSTS = [
-  "host.containers.internal",
-  "http-intake.logs.us5.datadoghq.com",
   "registry.npmjs.org",
   "pypi.org",
   "files.pythonhosted.org",
   "crates.io",
   "static.crates.io",
 ];
+
+// Check if hostname (+ optional port) matches a bypass list entry.
+// Entry format: "host" (any port) or "host:port" (exact port required).
+function isBypassHost(hosts: string[], hostname: string, port?: number): boolean {
+  return hosts.some((entry) => {
+    const lastColon = entry.lastIndexOf(":");
+    if (lastColon > 0) {
+      const entryPort = parseInt(entry.slice(lastColon + 1), 10);
+      if (!isNaN(entryPort)) {
+        const entryHost = entry.slice(0, lastColon);
+        const hostMatch = hostname === entryHost || hostname.endsWith(`.${entryHost}`);
+        return hostMatch && port === entryPort;
+      }
+    }
+    return hostname === entry || hostname.endsWith(`.${entry}`);
+  });
+}
 
 // Provider-specific bypass hosts come from PROXY_BYPASS_HOSTS env var (comma-separated)
 // e.g. "api.anthropic.com,statsig.anthropic.com" for Claude
@@ -166,17 +182,19 @@ function shannonEntropy(s: string): number {
 }
 
 function inspectRequest(method: string, url: string, headers: Record<string, string>, hasBody: boolean, domain: string): { allowed: boolean; reason: string } {
-  if (policy.bypassHosts.some((h) => domain === h || domain.endsWith(`.${h}`))) {
-    return { allowed: true, reason: "bypass_host" };
-  }
-
-  // Parse URL early — needed for both scoped allow and length/entropy checks
+  // Parse URL early — needed for bypass port check and length/entropy checks
   let urlPart = url;
+  let urlPort: number | undefined;
   try {
     const parsed = new URL(url.startsWith("http") ? url : `http://${domain}${url}`);
     urlPart = parsed.pathname + parsed.search;
+    if (parsed.port) urlPort = parseInt(parsed.port, 10);
   } catch {
     return { allowed: false, reason: "invalid_url" };
+  }
+
+  if (isBypassHost(policy.bypassHosts, domain, urlPort)) {
+    return { allowed: true, reason: "bypass_host" };
   }
 
   // Scoped allow — matches host + URL path prefix, allows all methods (POST, PUT, etc.)
@@ -493,7 +511,7 @@ async function getOrCreateMitmListener(hostname: string, upstreamPort: number): 
 
 async function handleConnect(clientSocket: Socket, hostname: string, upstreamPort: number, taskId: string) {
   // Bypass hosts — tunnel directly without MITM
-  if (policy.bypassHosts.some((h) => hostname === h || hostname.endsWith(`.${h}`))) {
+  if (isBypassHost(policy.bypassHosts, hostname, upstreamPort)) {
     log("ALLOW", "CONNECT", `${hostname}:${upstreamPort}`, "bypass_host", taskId);
     const upstream = new Socket();
     upstream.connect(upstreamPort, hostname, () => {

--- a/container/tests/network-proxy-test.sh
+++ b/container/tests/network-proxy-test.sh
@@ -14,6 +14,7 @@ SKIP=0
 TESTS=0
 IMAGE="sandbox-claude"
 PROXY="http://host.containers.internal:3128"
+SERVER_PORT="${SERVER_PORT:-4000}"
 
 # ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -98,6 +99,14 @@ fi
 
 echo "Proxy container: running"
 echo "Image: $IMAGE"
+echo "Server port: $SERVER_PORT"
+
+# Verify proxy has the correct server port bypass
+PROXY_ENV=$(podman inspect ysa-proxy --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null)
+if ! echo "$PROXY_ENV" | grep -q "host\.containers\.internal:${SERVER_PORT}"; then
+  echo "WARNING: Proxy does not have host.containers.internal:${SERVER_PORT} in PROXY_BYPASS_HOSTS."
+  echo "  Bypass port tests will reflect that. Start proxy via ensureProxy() with the correct serverPort."
+fi
 echo ""
 
 # ─── 1. HTTP Method Filtering ────────────────────────────────────────────
@@ -294,15 +303,24 @@ check "Cannot exfiltrate via long URL path (encoded)" \
 echo ""
 
 # ─── 11. Bypass Hosts ───────────────────────────────────────────────────
-echo "--- 11. Bypass Host (host.containers.internal) ---"
-# Bypass host should allow ALL methods (needed for prompt delivery + dashboard API)
-check "Bypass host GET allowed" \
+echo "--- 11. Bypass Hosts (port-restricted) ---"
+# host.containers.internal is port-restricted: only SERVER_PORT is bypassed (all methods allowed)
+# Any other port goes through strict policy (POST blocked, GET inspected)
+check "Correct port on host.containers.internal: GET allowed (bypassed)" \
   "allow" \
-  'curl -sf -o /dev/null -w "%{http_code}" -x '"$PROXY"' http://host.containers.internal:4000/ 2>/dev/null; true'
+  'curl -sf -o /dev/null -w "%{http_code}" -x '"$PROXY"' http://host.containers.internal:'"$SERVER_PORT"'/ 2>/dev/null; true'
 
-check "Bypass host POST allowed" \
+check "Correct port on host.containers.internal: POST allowed (bypassed)" \
   "allow" \
-  'curl -sf -o /dev/null -w "%{http_code}" -x '"$PROXY"' -X POST -d "data" http://host.containers.internal:4000/ 2>/dev/null; true'
+  'curl -sf -o /dev/null -w "%{http_code}" -x '"$PROXY"' -X POST -d "data" http://host.containers.internal:'"$SERVER_PORT"'/ 2>/dev/null; true'
+
+check "Wrong port on host.containers.internal: POST blocked (not bypassed)" \
+  "block" \
+  'curl -sf -x '"$PROXY"' -X POST -d "data" http://host.containers.internal:9999/'
+
+check "Datadog telemetry endpoint blocked" \
+  "block" \
+  'curl -sf -x '"$PROXY"' http://http-intake.logs.us5.datadoghq.com/v1/input'
 
 echo ""
 
@@ -525,16 +543,18 @@ else
 fi
 
 # Server port allowed
-echo -n "  [$((TESTS + 1))] Server port (4000) allowed by iptables ... "
+# exit 0 = HTTP response, exit 7 = TCP refused (port reachable, no server) — both mean iptables allowed it
+# exit 28 = timeout — iptables dropped it
+echo -n "  [$((TESTS + 1))] Server port ($SERVER_PORT) allowed by iptables ... "
 TESTS=$((TESTS + 1))
-code=$(podman run --rm --network slirp4netns \
+curl_exit=$(podman run --rm --network slirp4netns \
   --annotation network_policy=strict \
-  "$IMAGE" -c 'curl -s --connect-timeout 5 -o /dev/null -w "%{http_code}" http://host.containers.internal:4000/' 2>&1)
-if [ "$code" != "000" ]; then
-  echo "PASS (connection allowed, HTTP $code)"
+  "$IMAGE" -c "curl -s --connect-timeout 5 -o /dev/null http://host.containers.internal:${SERVER_PORT}/; echo \$?" 2>&1 | tail -1)
+if [ "$curl_exit" = "0" ] || [ "$curl_exit" = "7" ]; then
+  echo "PASS (port reachable, curl exit $curl_exit)"
   PASS=$((PASS + 1))
 else
-  echo "FAIL (connection blocked)"
+  echo "FAIL (port blocked — curl exit $curl_exit)"
   FAIL=$((FAIL + 1))
 fi
 

--- a/src/api/task-actions.ts
+++ b/src/api/task-actions.ts
@@ -174,7 +174,7 @@ export const taskActionsRouter = router({
 
       // Ensure proxy is running if strict mode
       if (networkPolicy === "strict") {
-        await ensureProxy(scopedRules.length > 0 ? scopedRules : undefined, bypassHosts);
+        await ensureProxy(scopedRules.length > 0 ? scopedRules : undefined, bypassHosts, serverConfig.port);
       }
 
       // Insert queued task
@@ -320,7 +320,7 @@ export const taskActionsRouter = router({
       const taskNetworkPolicy = (task.network_policy ?? "none") as "none" | "strict";
       if (taskNetworkPolicy === "strict") {
         const { scopedRules, bypassHosts: extraBypass } = parseAllowedHosts(task.allowed_hosts);
-        await ensureProxy(scopedRules.length > 0 ? scopedRules : undefined, [...getProvider(task.provider ?? "claude").bypassHosts, ...extraBypass]);
+        await ensureProxy(scopedRules.length > 0 ? scopedRules : undefined, [...getProvider(task.provider ?? "claude").bypassHosts, ...extraBypass], serverConfig.port);
       }
 
       const config: RunConfig = {
@@ -400,7 +400,7 @@ export const taskActionsRouter = router({
       const continueNetworkPolicy = (task.network_policy ?? "none") as "none" | "strict";
       if (continueNetworkPolicy === "strict") {
         const { scopedRules, bypassHosts: extraBypass } = parseAllowedHosts(task.allowed_hosts);
-        await ensureProxy(scopedRules.length > 0 ? scopedRules : undefined, [...getProvider(task.provider ?? "claude").bypassHosts, ...extraBypass]);
+        await ensureProxy(scopedRules.length > 0 ? scopedRules : undefined, [...getProvider(task.provider ?? "claude").bypassHosts, ...extraBypass], serverConfig.port);
       }
 
       const config: RunConfig = {
@@ -480,7 +480,7 @@ export const taskActionsRouter = router({
       const refineNetworkPolicy = (task.network_policy ?? "none") as "none" | "strict";
       if (refineNetworkPolicy === "strict") {
         const { scopedRules, bypassHosts: extraBypass } = parseAllowedHosts(task.allowed_hosts);
-        await ensureProxy(scopedRules.length > 0 ? scopedRules : undefined, [...getProvider(task.provider ?? "claude").bypassHosts, ...extraBypass]);
+        await ensureProxy(scopedRules.length > 0 ? scopedRules : undefined, [...getProvider(task.provider ?? "claude").bypassHosts, ...extraBypass], serverConfig.port);
       }
 
       const config: RunConfig = {
@@ -616,7 +616,7 @@ export const taskActionsRouter = router({
 
       if (taskNetPolicy === "strict") {
         const { scopedRules, bypassHosts: extraBypass } = parseAllowedHosts(task.allowed_hosts);
-        await ensureProxy(scopedRules.length > 0 ? scopedRules : undefined, [...taskAdapter.bypassHosts, ...extraBypass]);
+        await ensureProxy(scopedRules.length > 0 ? scopedRules : undefined, [...taskAdapter.bypassHosts, ...extraBypass], serverConfig.port);
       }
 
       const launcherPath = `/tmp/claude-refine-${input.taskId}.sh`;

--- a/src/runtime/proxy.ts
+++ b/src/runtime/proxy.ts
@@ -104,9 +104,10 @@ export async function stopProxy(): Promise<void> {
   await runShell(`podman rm -f ${PROXY_CONTAINER_NAME} 2>/dev/null || true`);
 }
 
-export async function ensureProxy(scopedRules?: ScopedAllowRule[], bypassHosts?: string[]): Promise<void> {
+export async function ensureProxy(scopedRules?: ScopedAllowRule[], bypassHosts?: string[], serverPort?: number): Promise<void> {
   const needed = scopedRules ?? [];
   const hosts = bypassHosts ?? DEFAULT_BYPASS_HOSTS;
+  const allHosts = serverPort ? [...hosts, `host.containers.internal:${serverPort}`] : hosts;
   const running = await isProxyRunning();
 
   if (running) {
@@ -115,7 +116,7 @@ export async function ensureProxy(scopedRules?: ScopedAllowRule[], bypassHosts?:
     const missingRules = needed.filter(
       (n) => !containerRules.some((c) => c.host === n.host && c.pathPrefix === n.pathPrefix),
     );
-    const missingHosts = hosts.filter((h) => !containerHosts.includes(h));
+    const missingHosts = allHosts.filter((h) => !containerHosts.includes(h));
     if (missingRules.length === 0 && missingHosts.length === 0) return;
 
     await stopProxy();
@@ -123,6 +124,6 @@ export async function ensureProxy(scopedRules?: ScopedAllowRule[], bypassHosts?:
     const mergedHosts = [...new Set([...containerHosts, ...missingHosts])];
     await startProxy(mergedRules, mergedHosts);
   } else {
-    await startProxy(needed, hosts);
+    await startProxy(needed, allHosts);
   }
 }


### PR DESCRIPTION
## Summary

- `host.containers.internal` removed from `BASE_BYPASS_HOSTS` — previously any port on the host was freely accessible; now callers pass their server port to `ensureProxy()` which injects `host.containers.internal:PORT` into the bypass list
- `http-intake.logs.us5.datadoghq.com` removed from `BASE_BYPASS_HOSTS` — was being bypassed entirely despite the intent (per CLAUDE.md) being to block it silently; it remains in `HIDDEN_LOG_HOSTS` so block noise stays hidden from the UI
- Added `isBypassHost()` helper with `host:port` parsing — port-qualified entries require exact port match, plain host entries keep existing any-port behavior
- Updated all `ensureProxy()` call sites in `task-actions.ts` to pass `serverConfig.port`
- Proxy image is generic — zero hardcoded assumptions about host port; each app declares its own

## Test plan

- [x] `network-proxy-test.sh` 62/62 passing
- [x] Correct port bypassed (GET + POST allowed)
- [x] Wrong port not bypassed (POST blocked)
- [x] Datadog endpoint blocked
- [x] OCI hook server port test no longer requires a running server
- [x] Tested end-to-end on ysa (port 4000) and platform dashboard (port 3333)