### PR TITLE
fix: authenticate prompt HTTP endpoint with shared secret token

### DIFF
--- a/container/sandbox-run.sh
+++ b/container/sandbox-run.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
-# sandbox-run.sh — Launch a hardened sandbox container for an AI agent session
+# sandbox-run.sh -- Launch a hardened sandbox container for an AI agent session
 #
 # Usage: sandbox-run.sh <worktree> <repo_git_dir> <branch> <mode> <task_id> [command...]
 #
 # Modes: readonly, readwrite
 #
-# Mounts: worktree (/workspace), git dir (/repo.git) — nothing else.
+# Mounts: worktree (/workspace), git dir (/repo.git) -- nothing else.
 # Session persistence via podman named volume (task-session-{task_id}).
 # Log capture via stdout pipe on host (tee).
 #
 # Required env vars:
-#   CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY — auth for Claude CLI
+#   CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY -- auth for Claude CLI
 # Optional env vars:
-#   SANDBOX_TIMEOUT    — container timeout in seconds (default: 3600)
-#   LOG_FILE           — host path for output log (captured via tee)
+#   SANDBOX_TIMEOUT    -- container timeout in seconds (default: 3600)
+#   LOG_FILE           -- host path for output log (captured via tee)
 
 set -euo pipefail
 
@@ -22,7 +22,7 @@ IMAGE="${AGENT_IMAGE:-sandbox-claude}"
 SECCOMP_PROFILE="$SCRIPT_DIR/seccomp.json"
 TIMEOUT="${SANDBOX_TIMEOUT:-3600}"  # default 1 hour
 
-# ── Args ──────────────────────────────────────────────────────────────
+# -- Args ----------------------------------------------------------------------
 if [ $# -lt 5 ]; then
   echo "Usage: $0 <worktree> <repo_git_dir> <branch> <mode> <task_id> [command...]"
   echo "Modes: readonly, readwrite"
@@ -53,7 +53,7 @@ for arg in "$@"; do
   QUOTED_ARGS+=" $escaped"
 done
 
-# ── Validate ──────────────────────────────────────────────────────────
+# -- Validate ------------------------------------------------------------------
 if [ ! -d "$WORKTREE" ]; then
   echo "ERROR: Worktree not found: $WORKTREE" >&2; exit 1
 fi
@@ -66,7 +66,7 @@ fi
 
 WORKTREE_NAME="$(basename "$WORKTREE")"
 
-# ── Mode-based access control ────────────────────────────────────────
+# -- Mode-based access control ------------------------------------------------
 case "$MODE" in
   readonly)
     REPO_MOUNT="$REPO_GIT:/repo.git:ro"
@@ -82,17 +82,17 @@ case "$MODE" in
     ;;
 esac
 
-# ── Session volume ────────────────────────────────────────────────────
+# -- Session volume ------------------------------------------------------------
 SESSION_VOLUME="task-session-${TASK_ID}"
 podman volume exists "$SESSION_VOLUME" 2>/dev/null || podman volume create "$SESSION_VOLUME" >/dev/null
 
-# ── Git worktree pointer ──────────────────────────────────────────────
+# -- Git worktree pointer ------------------------------------------------------
 # Write container-internal git pointers from the host before container starts,
 # so the container sees the correct paths without needing write access to them.
 echo "gitdir: /repo.git/worktrees/$WORKTREE_NAME" > "$WORKTREE/.git"
 echo "/workspace/.git" > "$REPO_GIT/worktrees/$WORKTREE_NAME/gitdir"
 
-# ── Network policy ───────────────────────────────────────────────────
+# -- Network policy -----------------------------------------------------------
 NETWORK_POLICY="${NETWORK_POLICY:-none}"
 NETWORK_FLAGS=""
 PROXY_ENV_FLAGS=""
@@ -106,7 +106,7 @@ if [ "$NETWORK_POLICY" = "strict" ] || [ "$NETWORK_POLICY" = "custom" ]; then
   fi
 fi
 
-# ── Audit log (to stderr, captured by caller) ─────────────────────────
+# -- Audit log (to stderr, captured by caller) ---------------------------------
 echo "=== Sandbox Audit Log ===" >&2
 echo "Mode: $SANDBOX_MODE" >&2
 echo "Task: $TASK_ID" >&2
@@ -120,26 +120,26 @@ echo "OAuth: ${CLAUDE_CODE_OAUTH_TOKEN:+set}" >&2
 echo "API Key: ${ANTHROPIC_API_KEY:+set}" >&2
 echo "=========================" >&2
 
-# ── Runtime version checks ────────────────────────────────────────────
+# -- Runtime version checks ----------------------------------------------------
 podman_ver=$(podman version --format '{{.Client.Version}}' 2>/dev/null || echo "unknown")
 runtime_ver=$(podman info --format '{{.Host.OCIRuntime.Name}} {{.Host.OCIRuntime.Version}}' 2>/dev/null | head -1 || echo "unknown")
 echo "Podman: $podman_ver, Runtime: $runtime_ver" >&2
 
-# ── Progress helper ──────────────────────────────────────────────────
+# -- Progress helper ----------------------------------------------------------
 progress() {
   if [ -n "${LOG_FILE:-}" ]; then
-    printf '{\"type\":\"system\",\"subtype\":\"progress\",\"message\":\"%s\"}\n' "$1" >> "$LOG_FILE"
+    printf '{"type":"system","subtype":"progress","message":"%s"}\n' "$1" >> "$LOG_FILE"
   fi
 }
 
-# ── Log capture setup ─────────────────────────────────────────────────
+# -- Log capture setup ---------------------------------------------------------
 if [ -n "${LOG_FILE:-}" ]; then
   TEE_CMD="tee -a $LOG_FILE"
 else
   TEE_CMD="cat"
 fi
 
-# ── Log monitor (background — watches for max_turns / result) ────────
+# -- Log monitor (background -- watches for max_turns / result) ----------------
 MONITOR_PID=""
 cleanup_monitor() {
   if [ -n "$MONITOR_PID" ]; then
@@ -156,7 +156,7 @@ if [ -n "${LOG_FILE:-}" ]; then
   if [ -f "$LOG_FILE" ]; then
     INITIAL_LINES=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
   fi
-  # Configurable log patterns — override via env to support different providers
+  # Configurable log patterns -- override via env to support different providers
   MAX_TURNS_PATTERN="${MAX_TURNS_GREP_PATTERN:-^{.*\"subtype\":\"error_max_turns\"}"
   if [ -n "${RESULT_GREP_PATTERN:-}" ]; then
     RESULT_PATTERN="$RESULT_GREP_PATTERN"
@@ -171,7 +171,7 @@ if [ -n "${LOG_FILE:-}" ]; then
         podman stop "sandbox-${TASK_ID}" >/dev/null 2>&1 || true
         break
       fi
-      # Stop container once the agent outputs a result — the CLI may do
+      # Stop container once the agent outputs a result -- the CLI may do
       # post-session telemetry that can hang behind the proxy.
       if echo "$NEW_CONTENT" | grep -q "$RESULT_PATTERN" 2>/dev/null; then
         sleep 3
@@ -184,7 +184,7 @@ if [ -n "${LOG_FILE:-}" ]; then
   MONITOR_PID=$!
 fi
 
-# ── Auth env vars for container ───────────────────────────────────────
+# -- Auth env vars for container -----------------------------------------------
 # AGENT_AUTH_ENV_FLAGS is pre-built by the caller (e.g. "-e ANTHROPIC_API_KEY")
 # Fall back to Claude defaults if not set (backward compat).
 if [ -n "${AGENT_AUTH_ENV_FLAGS+x}" ]; then
@@ -201,7 +201,7 @@ fi
 
 progress "Starting container (network: $NETWORK_POLICY)..."
 
-# ── Launch container ──────────────────────────────────────────────────
+# -- Launch container ----------------------------------------------------------
 podman run --rm \
   --name "sandbox-${TASK_ID}" \
   --label "task=${TASK_ID}" \
@@ -231,6 +231,7 @@ podman run --rm \
   $PROXY_ENV_FLAGS \
   $NETWORK_FLAGS \
   -e PROMPT_URL="${PROMPT_URL:-}" \
+  -e PROMPT_TOKEN="${PROMPT_TOKEN:-}" \
   ${EXTRA_POD_ENV:-} \
   -e ALLOWED_TOOLS="$ALLOWED_TOOLS_VALUE" \
   -e ENABLE_TOOL_SEARCH=false \
@@ -243,8 +244,8 @@ podman run --rm \
   --mount "type=volume,src=${SESSION_VOLUME},dst=/home/agent" \
   "$IMAGE" \
   -c "
-    # Progress helper (JSON to stdout → tee → LOG_FILE)
-    _progress() { printf '{\"type\":\"system\",\"subtype\":\"progress\",\"message\":\"%s\"}\n' \"\$1\"; }
+    # Progress helper (JSON to stdout -> tee -> LOG_FILE)
+    _progress() { printf '{\"type\":\"system\",\"subtype\":\"progress\",\"message\":\"%s\"}\\n' \"\$1\"; }
 
     # Provider-specific init (settings files, config, onboarding bypass, etc.)
     # AGENT_INIT_SCRIPT is set by the caller; falls back to Claude defaults if unset.
@@ -281,7 +282,7 @@ podman run --rm \
       *)
         if [ -n \"\$PROMPT_URL\" ]; then
           _progress 'Fetching prompt...'
-          PROMPT=\$(curl -sf \"\$PROMPT_URL\")
+          PROMPT=\$(curl --max-time 30 -sf -H \"Authorization: Bearer \$PROMPT_TOKEN\" \"\$PROMPT_URL\")
           if [ -z \"\$PROMPT\" ]; then
             echo 'ERROR: Failed to fetch prompt from PROMPT_URL' >&2
             exit 1
@@ -302,7 +303,7 @@ echo "" >&2
 echo "Finished: $(date -u +%Y-%m-%dT%H:%M:%SZ)" >&2
 echo "Exit code: $EXIT_CODE" >&2
 
-# ── Restore host worktree pointer ─────────────────────────────────────
+# -- Restore host worktree pointer ---------------------------------------------
 echo "gitdir: $REPO_GIT/worktrees/$WORKTREE_NAME" > "$WORKTREE/.git"
 echo "$WORKTREE/.git" > "$REPO_GIT/worktrees/$WORKTREE_NAME/gitdir"
 

--- a/src/api/task-actions.ts
+++ b/src/api/task-actions.ts
@@ -10,7 +10,7 @@ import { removeWorktree } from "../runtime/worktree";
 import { getProvider } from "../providers";
 import { ensureProxy } from "../runtime/proxy";
 import type { ScopedAllowRule } from "../runtime/proxy";
-import { getServerConfig } from "./config-store";
+import { getServerConfig, getOrCreateAuthToken } from "./config-store";
 import type { RunConfig } from "../types";
 
 // Parse comma-separated allow entries into scoped rules + bypass hosts.
@@ -198,6 +198,7 @@ export const taskActionsRouter = router({
       const promptKey = taskId;
       await fetch(`http://localhost:${serverConfig.port}/api/prompt/${promptKey}`, {
         method: "POST",
+        headers: { Authorization: `Bearer ${getOrCreateAuthToken()}` },
         body: wrapPrompt(input.prompt),
       });
       const promptUrl = `http://host.containers.internal:${serverConfig.port}/api/prompt/${promptKey}`;
@@ -313,6 +314,7 @@ export const taskActionsRouter = router({
       // Store prompt for container to fetch (with result + abort instructions appended)
       await fetch(`http://localhost:${serverConfig.port}/api/prompt/${input.taskId}`, {
         method: "POST",
+        headers: { Authorization: `Bearer ${getOrCreateAuthToken()}` },
         body: wrapPrompt(task.prompt),
       });
       const promptUrl = `http://host.containers.internal:${serverConfig.port}/api/prompt/${input.taskId}`;

--- a/src/runtime/runner.ts
+++ b/src/runtime/runner.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import { getProvider } from "../providers";
 import { createWorktree, prepareWorktree } from "./worktree";
 import { spawnSandbox } from "./container";
+import { getOrCreateAuthToken } from "../api/config-store";
 import type { RunConfig, RunResult, TaskStatus } from "../types";
 
 function progressEntry(message: string): string {
@@ -30,7 +31,7 @@ export async function runTask(config: RunConfig): Promise<RunResult> {
   await mkdir(logDir, { recursive: true });
   await mkdir(config.worktreePrefix, { recursive: true });
 
-  // 1. Create worktree (skip if resuming — worktree already exists)
+  // 1. Create worktree (skip if resuming - worktree already exists)
   if (!config.resumeSessionId) {
     await appendFile(logPath, progressEntry("Creating git worktree..."));
     const wt = await createWorktree(config.projectRoot, worktree, branch, baseBranch);
@@ -78,6 +79,7 @@ export async function runTask(config: RunConfig): Promise<RunResult> {
   const startTime = Date.now();
   const env: Record<string, string> = { ...authEnv, ...containerConfig.envVars };
   if (config.promptUrl) env.PROMPT_URL = config.promptUrl;
+  env.PROMPT_TOKEN = getOrCreateAuthToken();
 
   const proc = spawnSandbox({
     worktree,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -29,17 +29,17 @@ app.use(
   }),
 );
 
-// ─── Prompt store (generic endpoint for container to fetch prompt) ────
+// Prompt store (generic endpoint for container to fetch prompt)
 const promptStore = new Map<string, string>();
 
-app.post("/api/prompt/:id", async (c) => {
+app.post("/api/prompt/:id", requireLocalToken, async (c) => {
   const id = c.req.param("id");
   const body = await c.req.text();
   promptStore.set(id, body);
   return c.json({ ok: true });
 });
 
-app.get("/api/prompt/:id", (c) => {
+app.get("/api/prompt/:id", requireLocalToken, (c) => {
   const id = c.req.param("id");
   const content = promptStore.get(id);
   if (!content) return c.text("", 404);
@@ -51,7 +51,7 @@ app.get("/api/token", (c) => {
   return c.text(getOrCreateAuthToken());
 });
 
-// Serve built Vite assets — inject token into index.html
+// Serve built Vite assets - inject token into index.html
 const distDir = join(import.meta.dir, "..", "..", "dist");
 app.get("/", async (c) => {
   const token = getOrCreateAuthToken();

--- a/src/server/prompt.test.ts
+++ b/src/server/prompt.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "bun:test";
+import { Hono } from "hono";
+import { createAuthMiddleware } from "./auth";
+
+const MOCK_TOKEN = "test-prompt-token-xyz789";
+
+function makePromptApp() {
+  const requireLocalToken = createAuthMiddleware(() => MOCK_TOKEN);
+  const promptStore = new Map<string, string>();
+  const app = new Hono();
+
+  app.post("/api/prompt/:id", requireLocalToken, async (c) => {
+    const id = c.req.param("id");
+    const body = await c.req.text();
+    promptStore.set(id, body);
+    return c.json({ ok: true });
+  });
+
+  app.get("/api/prompt/:id", requireLocalToken, (c) => {
+    const id = c.req.param("id");
+    const content = promptStore.get(id);
+    if (!content) return c.text("", 404);
+    return c.text(content);
+  });
+
+  return { app, promptStore };
+}
+
+describe("prompt endpoints", () => {
+  describe("GET /api/prompt/:id", () => {
+    it("ut-1: returns 401 when no Authorization header is present", async () => {
+      const { app, promptStore } = makePromptApp();
+      promptStore.set("task-1", "my prompt");
+      const res = await app.request("/api/prompt/task-1");
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body).toEqual({ error: "Unauthorized" });
+    });
+
+    it("ut-2: returns the stored prompt body when a valid Authorization: Bearer <token> header is sent", async () => {
+      const { app, promptStore } = makePromptApp();
+      promptStore.set("task-2", "my stored prompt content");
+      const res = await app.request("/api/prompt/task-2", {
+        headers: { Authorization: `Bearer ${MOCK_TOKEN}` },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toBe("my stored prompt content");
+    });
+
+    it("returns 404 for unknown prompt id with valid token", async () => {
+      const { app } = makePromptApp();
+      const res = await app.request("/api/prompt/unknown-id", {
+        headers: { Authorization: `Bearer ${MOCK_TOKEN}` },
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("POST /api/prompt/:id", () => {
+    it("ut-3: returns 401 when no Authorization header is present", async () => {
+      const { app } = makePromptApp();
+      const res = await app.request("/api/prompt/task-3", {
+        method: "POST",
+        body: "some prompt text",
+      });
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body).toEqual({ error: "Unauthorized" });
+    });
+
+    it("stores the prompt and returns ok when valid token is provided", async () => {
+      const { app, promptStore } = makePromptApp();
+      const res = await app.request("/api/prompt/task-4", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${MOCK_TOKEN}` },
+        body: "new prompt text",
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ ok: true });
+      expect(promptStore.get("task-4")).toBe("new prompt text");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `requireLocalToken` middleware to `GET /api/prompt/:id` and `POST /api/prompt/:id` routes, so any unauthenticated caller (local process, container escape attempt) gets a 401 instead of the prompt text
- Pass `PROMPT_TOKEN` env var to the sandbox container via `runner.ts` so the container has the shared secret at runtime
- Update `container/sandbox-run.sh` to forward `PROMPT_TOKEN` into the container (`-e PROMPT_TOKEN=...`) and add `-H "Authorization: Bearer $PROMPT_TOKEN"` plus `--max-time 30` to the `curl` fetch
- Update internal server-side `fetch()` calls in `task-actions.ts` (`run` and `relaunch` mutations) to send the `Authorization` header for defence-in-depth consistency

## Test plan

- [x] Unit tests added in `src/server/prompt.test.ts` covering:
  - `GET /api/prompt/:id` returns 401 without auth header (ut-1)
  - `GET /api/prompt/:id` returns prompt body with valid Bearer token (ut-2)
  - `POST /api/prompt/:id` returns 401 without auth header (ut-3)
  - POST stores prompt and returns `{ ok: true }` with valid token
- [x] All 10 unit tests pass (`bun test src/`)
- [x] TypeScript typecheck passes (`bun run typecheck`)
- [x] man-1: Start a task via UI, verify agent completes (RESULT.md produced), confirm `curl GET /api/prompt/<id>` without token → 401
- [x] man-2: Relaunch a failed/stopped task, verify it completes with correct prompt