### PR TITLE
fix: propagate host git identity and allow --force-with-lease in sandbox

### DIFF
--- a/container/container-sandbox-guard.sh
+++ b/container/container-sandbox-guard.sh
@@ -61,7 +61,7 @@ case "$TOOL_NAME" in
       echo "BLOCKED: Destructive 'rm' command not allowed in sandbox (task ${CONTEXT_ID})" >&2
       exit 2
     fi
-    if echo "$COMMAND" | grep -Eq 'git\s+push\s+.*--force'; then
+    if echo "$COMMAND" | grep -Eq 'git\s+push\s+.*--force([^-]|$)'; then
       echo "BLOCKED: 'git push --force' not allowed in sandbox (task ${CONTEXT_ID})" >&2
       exit 2
     fi

--- a/container/sandbox-run.sh
+++ b/container/sandbox-run.sh
@@ -82,6 +82,12 @@ case "$MODE" in
     ;;
 esac
 
+# ── Host git identity ─────────────────────────────────────────────────
+GIT_AUTHOR_NAME="${GIT_AUTHOR_NAME:-$(git config user.name 2>/dev/null || echo "Sandbox Agent")}"
+GIT_AUTHOR_EMAIL="${GIT_AUTHOR_EMAIL:-$(git config user.email 2>/dev/null || echo "agent@sandbox")}"
+GIT_COMMITTER_NAME="${GIT_COMMITTER_NAME:-$GIT_AUTHOR_NAME}"
+GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-$GIT_AUTHOR_EMAIL}"
+
 # ── Session volume ────────────────────────────────────────────────────
 SESSION_VOLUME="task-session-${TASK_ID}"
 podman volume exists "$SESSION_VOLUME" 2>/dev/null || podman volume create "$SESSION_VOLUME" >/dev/null
@@ -234,10 +240,10 @@ podman run --rm \
   ${EXTRA_POD_ENV:-} \
   -e ALLOWED_TOOLS="$ALLOWED_TOOLS_VALUE" \
   -e ENABLE_TOOL_SEARCH=false \
-  -e GIT_AUTHOR_NAME="Sandbox Agent" \
-  -e GIT_AUTHOR_EMAIL="agent@sandbox" \
-  -e GIT_COMMITTER_NAME="Sandbox Agent" \
-  -e GIT_COMMITTER_EMAIL="agent@sandbox" \
+  -e GIT_AUTHOR_NAME="${GIT_AUTHOR_NAME:-Sandbox Agent}" \
+  -e GIT_AUTHOR_EMAIL="${GIT_AUTHOR_EMAIL:-agent@sandbox}" \
+  -e GIT_COMMITTER_NAME="${GIT_COMMITTER_NAME:-Sandbox Agent}" \
+  -e GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-agent@sandbox}" \
   -v "$WORKTREE:/workspace:rw" \
   -v "$REPO_MOUNT" \
   --mount "type=volume,src=${SESSION_VOLUME},dst=/home/agent" \


### PR DESCRIPTION
## Summary

- `sandbox-run.sh`: read `git config user.name` / `git config user.email` from the host and pass them as `GIT_AUTHOR_NAME` / `GIT_COMMITTER_NAME` into the container, falling back to `Sandbox Agent / agent@sandbox` if unset
- `container-sandbox-guard.sh`: fix `--force` regex to `--force([^-]|$)` so `--force-with-lease` is allowed; bare `--force` remains blocked; `git-push-guard.sh` still restricts all pushes to `ALLOWED_BRANCH` only