### PR TITLE
fix: move sandbox guard to read-only image layer to prevent tampering

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -57,18 +57,18 @@ RUN rm -f /usr/bin/passwd /usr/bin/chage /usr/bin/chfn /usr/bin/chsh \
          /usr/bin/wget /usr/bin/nc /usr/bin/netcat \
          2>/dev/null || true
 
-# Claude hooks and settings (security guard for in-container tool use)
-# Installed in /home/agent/.claude for direct use (e.g. attack-test.sh)
-# AND in /etc/claude-defaults for volume-mount initialization (see sandbox-run.sh)
-RUN mkdir -p /home/agent/.claude/hooks && chown -R agent:agent /home/agent/.claude
-COPY container-sandbox-guard.sh /home/agent/.claude/hooks/sandbox-guard.sh
-COPY claude-settings.json /home/agent/.claude/settings.json
-RUN chmod +x /home/agent/.claude/hooks/sandbox-guard.sh && \
+# Claude settings and security guard
+# settings.json goes into /home/agent/.claude (seeded into new session volumes)
+# sandbox-guard.sh goes ONLY into /etc/claude-defaults/hooks (read-only image layer)
+# settings.json references /etc/claude-defaults/hooks/sandbox-guard.sh so the agent
+# cannot modify the active hook regardless of what it does to /home/agent
+RUN mkdir -p /home/agent/.claude /etc/claude-defaults/hooks && \
     chown -R agent:agent /home/agent/.claude
-RUN mkdir -p /etc/claude-defaults/hooks && \
-    cp /home/agent/.claude/settings.json /etc/claude-defaults/settings.json && \
-    cp /home/agent/.claude/hooks/sandbox-guard.sh /etc/claude-defaults/hooks/sandbox-guard.sh && \
-    chmod +x /etc/claude-defaults/hooks/sandbox-guard.sh
+COPY claude-settings.json /home/agent/.claude/settings.json
+COPY claude-settings.json /etc/claude-defaults/settings.json
+COPY container-sandbox-guard.sh /etc/claude-defaults/hooks/sandbox-guard.sh
+RUN chmod +x /etc/claude-defaults/hooks/sandbox-guard.sh && \
+    chown -R agent:agent /home/agent/.claude
 
 # Network proxy — install shared CA cert so the agent trusts the MITM proxy
 COPY ca.pem /usr/local/share/ca-certificates/ysa-proxy-ca.crt

--- a/container/claude-settings.json
+++ b/container/claude-settings.json
@@ -11,7 +11,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/agent/.claude/hooks/sandbox-guard.sh"
+            "command": "/etc/claude-defaults/hooks/sandbox-guard.sh"
           }
         ]
       }

--- a/container/container-sandbox-guard.sh
+++ b/container/container-sandbox-guard.sh
@@ -93,6 +93,10 @@ case "$TOOL_NAME" in
       echo "BLOCKED: Copying .env files not allowed in sandbox (task ${CONTEXT_ID})" >&2
       exit 2
     fi
+    if echo "$COMMAND" | grep -Eq '(~/|/home/agent/)\.claude/(settings\.json|hooks/)'; then
+      echo "BLOCKED: Modifying Claude configuration is not allowed in sandbox (task ${CONTEXT_ID})" >&2
+      exit 2
+    fi
 
     exit 0
     ;;

--- a/container/sandbox-run.sh
+++ b/container/sandbox-run.sh
@@ -147,11 +147,13 @@ fi
 
 # -- Log monitor (background -- watches for max_turns / result) ----------------
 MONITOR_PID=""
+SETTINGS_TMP=""
 cleanup_monitor() {
   if [ -n "$MONITOR_PID" ]; then
     kill "$MONITOR_PID" 2>/dev/null || true
     wait "$MONITOR_PID" 2>/dev/null || true
   fi
+  rm -f "${SETTINGS_TMP:-}"
 }
 trap cleanup_monitor EXIT
 
@@ -205,6 +207,22 @@ else
   fi
 fi
 
+# -- Generate read-only settings.json on host --------------------------------
+# settings.json is mounted :ro so the agent cannot modify the hook reference.
+# Claude Code does not write to settings.json during normal operation (confirmed).
+# ALLOWED_TOOLS injection is best-effort: if jq is unavailable, the --allowedTools
+# CLI flag already enforces restrictions and the injection is redundant.
+SETTINGS_TMP=$(mktemp)
+if [ -n "$ALLOWED_TOOLS_VALUE" ] && command -v jq >/dev/null 2>&1; then
+  TOOLS_JSON=$(echo "$ALLOWED_TOOLS_VALUE" | tr ',' '\n' | jq -R . | jq -s . 2>/dev/null || echo '[]')
+  jq --argjson t "$TOOLS_JSON" \
+    'if ($t | length) > 0 then .permissions.allow = $t else . end' \
+    "$SCRIPT_DIR/claude-settings.json" > "$SETTINGS_TMP" 2>/dev/null \
+    || cp "$SCRIPT_DIR/claude-settings.json" "$SETTINGS_TMP"
+else
+  cp "$SCRIPT_DIR/claude-settings.json" "$SETTINGS_TMP"
+fi
+
 progress "Starting container (network: $NETWORK_POLICY)..."
 
 # -- Launch container ----------------------------------------------------------
@@ -248,6 +266,7 @@ podman run --rm \
   -v "$WORKTREE:/workspace:rw" \
   -v "$REPO_MOUNT" \
   --mount "type=volume,src=${SESSION_VOLUME},dst=/home/agent" \
+  -v "$SETTINGS_TMP:/home/agent/.claude/settings.json:ro" \
   "$IMAGE" \
   -c "
     # Progress helper (JSON to stdout -> tee -> LOG_FILE)

--- a/container/tests/attack-test.sh
+++ b/container/tests/attack-test.sh
@@ -548,6 +548,14 @@ check "gpg.program overridden to empty" "allow" '[ -z "$(git -C /workspace confi
 check "protocol.ext.allow locked to never" "allow" '[ "$(git -C /workspace config protocol.ext.allow)" = "never" ]'
 
 echo ""
+echo "--- 39. Guard Tamper Protection ---"
+check "Hook guard in read-only image layer (write blocked)" "block" 'echo "pwned" > /etc/claude-defaults/hooks/sandbox-guard.sh'
+check "Hook guard cannot be patched via sed" "block" 'sed -i "s/BLOCKED/ALLOWED/" /etc/claude-defaults/hooks/sandbox-guard.sh'
+check "settings.json is read-only (bind mount)" "block" 'echo "{}" > /home/agent/.claude/settings.json'
+check "settings.json references immutable guard path" "allow" 'grep -q "etc/claude-defaults/hooks/sandbox-guard.sh" /home/agent/.claude/settings.json'
+check "Hook guard is executable at image-layer path" "allow" '[ -x /etc/claude-defaults/hooks/sandbox-guard.sh ]'
+
+echo ""
 echo "=========================================="
 echo " RESULTS: $PASS passed, $FAIL failed out of $TESTS tests"
 echo "=========================================="


### PR DESCRIPTION
## Summary

- The PreToolUse hook script lived in the writable session volume (`/home/agent/.claude/hooks/`), allowing the agent to patch it with `sed`, `echo >`, or any other shell write method
- Move the guard exclusively to `/etc/claude-defaults/hooks/sandbox-guard.sh` (read-only image layer) — the agent cannot write to image layer paths regardless of how the path is expressed
- Remove the writable volume copy entirely; single source of truth in the image
- `settings.json` is now generated on the host and mounted `:ro` at container start, so the hook reference cannot be altered mid-session
- Adds attack-test section 39 to verify tamper protection at runtime

## Test plan

- [x] Run `bash container/tests/run-attack-test.sh` — section 39 should pass
- [x] Launch a task and verify the guard still blocks destructive commands
- [x] Attempt to modify `/etc/claude-defaults/hooks/sandbox-guard.sh` from inside the container — should fail with permission denied