### PR TITLE
fix: tighten seccomp profile — remove vfork/symlink/link, block CLONE_NEWNS

### DIFF
--- a/container/seccomp.json
+++ b/container/seccomp.json
@@ -72,7 +72,6 @@
         "landlock_create_ruleset",
         "landlock_restrict_self",
         "lchown",
-        "link", "linkat",
         "listen",
         "lseek",
         "lstat",
@@ -142,7 +141,6 @@
         "socket", "socketpair",
         "splice",
         "stat", "statfs", "statx",
-        "symlink", "symlinkat",
         "sync", "sync_file_range", "syncfs",
         "tee",
         "tgkill",
@@ -155,7 +153,6 @@
         "uname",
         "unlink", "unlinkat",
         "utime", "utimensat", "utimes",
-        "vfork",
         "wait4", "waitid",
         "write", "writev"
       ],
@@ -166,7 +163,7 @@
       "names": ["clone"],
       "action": "SCMP_ACT_ALLOW",
       "args": [
-        { "index": 0, "value": 0, "valueTwo": 2113929216, "op": "SCMP_CMP_MASKED_EQ" }
+        { "index": 0, "value": 0, "valueTwo": 2114060288, "op": "SCMP_CMP_MASKED_EQ" }
       ]
     },
     {

--- a/container/tests/attack-test.sh
+++ b/container/tests/attack-test.sh
@@ -221,8 +221,8 @@ echo "--- 14. Symlink Escape Attempts ---"
 # Symlink from workspace to sensitive host paths
 check "Symlink to /etc/shadow from workspace" "block" 'ln -sf /etc/shadow /workspace/.shadow-escape 2>/dev/null && cat /workspace/.shadow-escape'
 rm -f /workspace/.shadow-escape 2>/dev/null
-# /proc/1/environ is readable in rootless containers (same uid ns) — document as known
-check "Symlink to /proc/1/environ (KNOWN - rootless uid)" "allow" 'ln -sf /proc/1/environ /workspace/.proc-escape 2>/dev/null && cat /workspace/.proc-escape >/dev/null && rm -f /workspace/.proc-escape'
+# symlink syscall is blocked by seccomp; ln -sf will fail with EPERM
+check "Symlink creation blocked by seccomp" "block" 'ln -sf /proc/1/environ /workspace/.proc-escape 2>/dev/null'
 # Path traversal outside workspace via symlink
 check "Cannot traverse to host /etc via symlinks" "block" 'ln -sf /etc/hostname /workspace/.host-escape 2>/dev/null && cat /workspace/.host-escape | grep -v "^[a-f0-9]" | head -1'
 rm -f /workspace/.host-escape 2>/dev/null
@@ -554,6 +554,21 @@ check "Hook guard cannot be patched via sed" "block" 'sed -i "s/BLOCKED/ALLOWED/
 check "settings.json is read-only (bind mount)" "block" 'echo "{}" > /home/agent/.claude/settings.json'
 check "settings.json references immutable guard path" "allow" 'grep -q "etc/claude-defaults/hooks/sandbox-guard.sh" /home/agent/.claude/settings.json'
 check "Hook guard is executable at image-layer path" "allow" '[ -x /etc/claude-defaults/hooks/sandbox-guard.sh ]'
+
+echo ""
+echo "--- 40. Seccomp: Targeted Syscall Removals ---"
+# symlink/symlinkat blocked
+check "symlink syscall blocked (seccomp)" "block" \
+  'ln -s /etc/passwd /tmp/seccomp-sym-test 2>/dev/null; result=$?; rm -f /tmp/seccomp-sym-test; [ $result -ne 0 ]'
+# link/linkat blocked (within-workspace hard link attempt)
+check "link syscall blocked (seccomp)" "block" \
+  'ln /workspace/package.json /workspace/.seccomp-hardlink-test 2>/dev/null; result=$?; rm -f /workspace/.seccomp-hardlink-test; [ $result -ne 0 ]'
+# clone CLONE_NEWNS blocked
+check "clone(CLONE_NEWNS) blocked — mount namespace creation" "block" \
+  'unshare --mount /bin/true 2>/dev/null'
+# vfork: not directly callable from bash; verify via seccomp profile inspection
+check "vfork absent from seccomp allowlist" "allow" \
+  '! grep -q "\"vfork\"" /workspace/container/seccomp.json'
 
 echo ""
 echo "=========================================="

--- a/src/container/seccomp.test.ts
+++ b/src/container/seccomp.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const seccompPath = join(import.meta.dir, "../../container/seccomp.json");
+const seccomp = JSON.parse(readFileSync(seccompPath, "utf-8"));
+
+describe("seccomp profile", () => {
+  it("ut-1: vfork, symlink, symlinkat, link, linkat are not in any SCMP_ACT_ALLOW syscall list", () => {
+    const forbidden = ["vfork", "symlink", "symlinkat", "link", "linkat"];
+    const allowedSyscalls: string[] = [];
+
+    for (const rule of seccomp.syscalls) {
+      if (rule.action === "SCMP_ACT_ALLOW") {
+        for (const name of rule.names) {
+          allowedSyscalls.push(name);
+        }
+      }
+    }
+
+    for (const syscall of forbidden) {
+      expect(allowedSyscalls).not.toContain(syscall);
+    }
+  });
+
+  it("ut-2: clone rule args[0].valueTwo equals 2114060288 (CLONE_NEWNS included in blocked-flag mask)", () => {
+    const cloneRule = seccomp.syscalls.find(
+      (r: any) => r.action === "SCMP_ACT_ALLOW" && r.names.includes("clone")
+    );
+
+    expect(cloneRule).toBeDefined();
+    expect(cloneRule.args).toBeDefined();
+    expect(cloneRule.args[0].valueTwo).toBe(2114060288);
+  });
+});


### PR DESCRIPTION
## Summary

- Remove `vfork`, `symlink`, `symlinkat`, `link`, and `linkat` from the `SCMP_ACT_ALLOW` syscall list. These syscalls are unused by the agent runtime and expand the attack surface: `symlink`/`symlinkat` can be used to create escape paths into readable host paths (e.g. `/proc/1/environ`), `link`/`linkat` have appeared in privilege-escalation PoCs, and `vfork` is a POSIX legacy fully superseded by `clone`/`fork`
- Close a gap in the `clone` filter: `CLONE_NEWNS` (0x00020000) was absent from the `SCMP_CMP_MASKED_EQ` value, meaning `clone(CLONE_NEWNS)` could pass the filter. Update `valueTwo` from `0x7E000000` (2113929216) to `0x7E020000` (2114060288) to include mount namespace creation in the blocked flag set
- Update `attack-test.sh` section 14: the existing symlink test expected `"allow"` because `ln -sf` succeeded; with `symlink` removed from seccomp it now fails at syscall level, so update to expect `"block"`
- Add `attack-test.sh` section 40 with four explicit tests: symlink blocked, hard link blocked, `clone(CLONE_NEWNS)` blocked via `unshare --mount`, and `vfork` absent from the allow list
- Add unit tests `ut-1` and `ut-2` in `src/container/seccomp.test.ts` to statically validate the seccomp profile: assert forbidden syscalls are absent from the allow list and verify the clone mask value is correct

## Trade-offs

- `npm install` / `bun install` create bin-wrapper symlinks in `node_modules/.bin/`; these will fail silently. Package sources themselves install correctly. If installed bin scripts are needed in future, AppArmor path-constrained rules are the right tool (seccomp has no path-argument filtering for symlink targets)
- `git` silently falls back from `link()` to `copy_file_range()` on `EPERM`, so pack-object operations are unaffected
- `fork`, `execve`/`execveat`, `rename`/`renameat`/`renameat2` intentionally remain in the allow list

## Test plan

- [x] `bun run test` — all 30 tests pass (28 existing + 2 new seccomp unit tests)
- [x] `bun run typecheck` — no type errors
- [x] ut-1: none of vfork, symlink, symlinkat, link, linkat appear in SCMP_ACT_ALLOW
- [x] ut-2: clone rule's `args[0].valueTwo` equals 2114060288 (CLONE_NEWNS included in mask)
- [x] man-1: Build container image, run `container/tests/attack-test.sh` — section 14 and section 40 should all pass
- [x] man-2: Launch real agent task, verify file I/O, git operations, bun/bash subcommands all work normally