### PR TITLE
fix: extend git-safe-wrapper blacklist with missing code-execution config keys

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -85,7 +85,7 @@ USER agent
 # These take highest precedence (after -c flags) and cannot be overridden
 # by local config. The wrapper strips wildcard patterns; these handle exact keys.
 # Ref: https://git-scm.com/docs/git-config#ENVIRONMENT
-ENV GIT_CONFIG_COUNT=17 \
+ENV GIT_CONFIG_COUNT=20 \
     GIT_CONFIG_KEY_0=core.fsmonitor \
     GIT_CONFIG_VALUE_0=false \
     GIT_CONFIG_KEY_1=core.hooksPath \
@@ -119,7 +119,13 @@ ENV GIT_CONFIG_COUNT=17 \
     GIT_CONFIG_KEY_15=sequence.editor \
     GIT_CONFIG_VALUE_15=true \
     GIT_CONFIG_KEY_16=protocol.ext.allow \
-    GIT_CONFIG_VALUE_16=never
+    GIT_CONFIG_VALUE_16=never \
+    GIT_CONFIG_KEY_17=core.worktreeConfig \
+    GIT_CONFIG_VALUE_17=false \
+    GIT_CONFIG_KEY_18=init.templateDir \
+    GIT_CONFIG_VALUE_18= \
+    GIT_CONFIG_KEY_19=blame.ignoreRevsFile \
+    GIT_CONFIG_VALUE_19=/dev/null
 
 WORKDIR /workspace
 

--- a/container/git-safe-wrapper.sh
+++ b/container/git-safe-wrapper.sh
@@ -24,6 +24,10 @@
 #   url.*.insteadOf               — URL rewriting (can redirect to ext:: transport)
 #   sendemail.smtpServer          — sendmail program execution
 #   protocol.ext.allow            — ext:: transport command execution
+#   core.worktreeConfig           — loads per-worktree config that bypasses sanitization
+#   init.templateDir              — hooks in template dir run on git init/clone
+#   submodule.<name>.update       — accepts !<command> for arbitrary shell execution
+#   blame.ignoreRevsFile          — loads an arbitrary file path
 
 REAL_GIT=/usr/bin/git
 
@@ -42,8 +46,8 @@ work_dir="${target_dir:-.}"
 
 # Dangerous config key patterns (regex for grep -E)
 # These are keys whose VALUES are executed as shell commands by git
-DANGEROUS_EXACT_KEYS="core\.pager|core\.editor|core\.sshCommand|core\.askPass|core\.gitProxy|diff\.external|sequence\.editor|interactive\.diffFilter|gpg\.program|sendemail\.smtpServer"
-DANGEROUS_WILDCARD_KEYS="filter\.[^.]+\.(clean|smudge|process)|diff\.[^.]+\.(textconv|command)|merge\.[^.]+\.driver|pager\.[^.]+|gpg\.[^.]+\.program|trailer\.[^.]+\.(command|cmd)|include\.path|includeif\.[^.]+\.path|url\.[^.]+\.(insteadof|pushinsteadof)"
+DANGEROUS_EXACT_KEYS="core\.pager|core\.editor|core\.sshCommand|core\.askPass|core\.gitProxy|diff\.external|sequence\.editor|interactive\.diffFilter|gpg\.program|sendemail\.smtpServer|core\.worktreeConfig|init\.templateDir|blame\.ignoreRevsFile"
+DANGEROUS_WILDCARD_KEYS="filter\.[^.]+\.(clean|smudge|process)|diff\.[^.]+\.(textconv|command)|merge\.[^.]+\.driver|pager\.[^.]+|gpg\.[^.]+\.program|trailer\.[^.]+\.(command|cmd)|include\.path|includeif\.[^.]+\.path|url\.[^.]+\.(insteadof|pushinsteadof)|submodule\.[^.]+\.update"
 
 # Strip dangerous configs from ALL config locations
 # --git-common-dir gives the shared config (important for worktrees)

--- a/container/tests/attack-test.sh
+++ b/container/tests/attack-test.sh
@@ -565,6 +565,43 @@ check "vfork absent from seccomp allowlist" "allow" \
   '! grep -q "\"vfork\"" /workspace/container/seccomp.json'
 
 echo ""
+echo "--- 41. Git Config: Missing Blacklist Keys ---"
+
+# core.worktreeConfig injection: enable per-worktree config, plant a dangerous key there,
+# verify it does not execute
+rm -f /tmp/worktree-pwned 2>/dev/null
+mkdir -p /workspace/.git 2>/dev/null || true
+/usr/bin/git -C /workspace config --local core.worktreeConfig true 2>/dev/null || true
+printf '[core]\n\tpager = touch /tmp/worktree-pwned\n' > /workspace/.git/config.worktree 2>/dev/null || true
+git -C /workspace log --oneline -1 >/dev/null 2>&1 || true
+check "core.worktreeConfig injection — no side effect" "allow" '! [ -f /tmp/worktree-pwned ]'
+/usr/bin/git -C /workspace config --local --unset core.worktreeConfig 2>/dev/null || true
+rm -f /workspace/.git/config.worktree /tmp/worktree-pwned 2>/dev/null
+
+# init.templateDir injection: plant a malicious hook in a fake template dir,
+# set init.templateDir in local config, run git init in a temp dir, verify hook did not fire
+rm -f /tmp/template-pwned 2>/dev/null
+TMPDIR_INIT=$(mktemp -d /tmp/git-init-test-XXXXXX) 2>/dev/null || TMPDIR_INIT=/tmp/git-init-test-$$
+FAKE_TMPL=$(mktemp -d /tmp/git-template-XXXXXX) 2>/dev/null || FAKE_TMPL=/tmp/git-template-$$
+mkdir -p "$FAKE_TMPL/hooks"
+printf '#!/bin/bash\ntouch /tmp/template-pwned\n' > "$FAKE_TMPL/hooks/post-init" 2>/dev/null || true
+chmod +x "$FAKE_TMPL/hooks/post-init" 2>/dev/null || true
+/usr/bin/git -C /workspace config --local init.templateDir "$FAKE_TMPL" 2>/dev/null || true
+git init "$TMPDIR_INIT" >/dev/null 2>&1 || true
+check "init.templateDir injection — no side effect" "allow" '! [ -f /tmp/template-pwned ]'
+/usr/bin/git -C /workspace config --local --unset init.templateDir 2>/dev/null || true
+rm -rf "$TMPDIR_INIT" "$FAKE_TMPL" /tmp/template-pwned 2>/dev/null
+
+# submodule.<name>.update !cmd injection: set update = !cmd in local config,
+# run git submodule update, verify the command did not execute
+rm -f /tmp/submod-pwned 2>/dev/null
+/usr/bin/git -C /workspace config --local submodule.evil.update "!touch /tmp/submod-pwned" 2>/dev/null || true
+git -C /workspace submodule update >/dev/null 2>&1 || true
+check "submodule.evil.update !cmd injection — no side effect" "allow" '! [ -f /tmp/submod-pwned ]'
+/usr/bin/git -C /workspace config --local --unset submodule.evil.update 2>/dev/null || true
+rm -f /tmp/submod-pwned 2>/dev/null
+
+echo ""
 echo "=========================================="
 echo " RESULTS: $PASS passed, $FAIL failed out of $TESTS tests"
 echo "=========================================="

--- a/container/tests/git-safe-wrapper-test.sh
+++ b/container/tests/git-safe-wrapper-test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# git-safe-wrapper-test.sh — Unit tests for git-safe-wrapper.sh blacklist stripping
+#
+# Tests that the wrapper strips dangerous keys from local .git/config before
+# passing control to the real git binary.
+#
+# Usage: bash container/tests/git-safe-wrapper-test.sh
+# Requires: git installed at /usr/bin/git (or override REAL_GIT env var)
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+TESTS=0
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WRAPPER="$SCRIPT_DIR/../git-safe-wrapper.sh"
+REAL_GIT="${REAL_GIT:-/usr/bin/git}"
+
+if [ ! -x "$WRAPPER" ]; then
+  echo "ERROR: wrapper not found or not executable: $WRAPPER"
+  exit 1
+fi
+
+if [ ! -x "$REAL_GIT" ]; then
+  echo "ERROR: real git not found at $REAL_GIT"
+  exit 1
+fi
+
+# Create a temp repo for testing
+TMPDIR_REPO=$(mktemp -d /tmp/git-wrapper-test-XXXXXX)
+trap 'rm -rf "$TMPDIR_REPO"' EXIT
+
+"$REAL_GIT" init "$TMPDIR_REPO" --quiet
+"$REAL_GIT" -C "$TMPDIR_REPO" commit --allow-empty -m "init" --quiet
+
+check_stripped() {
+  TESTS=$((TESTS + 1))
+  local desc="$1"
+  local key="$2"
+  local value="$3"
+
+  # Inject the dangerous key via the real git binary (bypassing the wrapper)
+  "$REAL_GIT" -C "$TMPDIR_REPO" config --local "$key" "$value"
+
+  # Confirm the key was injected
+  if ! "$REAL_GIT" -C "$TMPDIR_REPO" config --local "$key" >/dev/null 2>&1; then
+    echo "  [$TESTS] SKIP (injection failed for $key)"
+    return
+  fi
+
+  # Run the wrapper with a harmless command (config --list) so it sanitises the config
+  # We run it from the repo directory so it picks up .git/config
+  REAL_GIT="$REAL_GIT" bash "$WRAPPER" -C "$TMPDIR_REPO" config --list >/dev/null 2>&1
+
+  # Check if the key was stripped
+  echo -n "  [$TESTS] $desc ... "
+  if "$REAL_GIT" -C "$TMPDIR_REPO" config --local "$key" >/dev/null 2>&1; then
+    echo "FAIL (key still present after wrapper run)"
+    FAIL=$((FAIL + 1))
+  else
+    echo "PASS (key stripped)"
+    PASS=$((PASS + 1))
+  fi
+}
+
+echo "=========================================="
+echo " git-safe-wrapper.sh unit tests"
+echo "=========================================="
+echo ""
+
+# ut-1: core.worktreeConfig stripped
+check_stripped "ut-1: core.worktreeConfig is stripped" "core.worktreeConfig" "true"
+
+# ut-2: init.templateDir stripped
+check_stripped "ut-2: init.templateDir is stripped" "init.templateDir" "/tmp/evil-tmpl"
+
+# ut-3: submodule.evil.update stripped
+check_stripped "ut-3: submodule.evil.update is stripped" "submodule.evil.update" "!touch /tmp/submod-pwned"
+
+# ut-4: blame.ignoreRevsFile stripped
+check_stripped "ut-4: blame.ignoreRevsFile is stripped" "blame.ignoreRevsFile" "/tmp/evil-revs"
+
+echo ""
+echo "=========================================="
+echo " RESULTS: $PASS passed, $FAIL failed out of $TESTS tests"
+echo "=========================================="
+
+if [ $FAIL -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
## Summary

- Add `core.worktreeConfig`, `init.templateDir`, and `blame.ignoreRevsFile` to `DANGEROUS_EXACT_KEYS` in `git-safe-wrapper.sh` — these keys allow config bypass or arbitrary file loading and were absent from the previous blacklist
- Add `submodule.<name>.update` to `DANGEROUS_WILDCARD_KEYS` — this key accepts `!<command>` values that execute arbitrary shell commands during `git submodule update`
- Bump `GIT_CONFIG_COUNT` from 17 to 20 in `Containerfile` and add env-var overrides for the three new exact keys as a second layer of defence (`core.worktreeConfig=false`, `init.templateDir=`, `blame.ignoreRevsFile=/dev/null`)
- Add section 41 to `container/tests/attack-test.sh` with three integration tests covering the new attack vectors
- Add `container/tests/git-safe-wrapper-test.sh` with four unit tests (ut-1 through ut-4) that verify each new key is stripped from local `.git/config` by the wrapper

## Attack vectors closed

| Key | Risk |
|---|---|
| `core.worktreeConfig` | Enables `.git/config.worktree` which is read after the wrapper already ran, bypassing sanitization |
| `init.templateDir` | Hooks copied from the template dir execute on `git init`/`git clone` |
| `submodule.<name>.update` | `update = !<cmd>` executes arbitrary shell on `git submodule update` |
| `blame.ignoreRevsFile` | Loads an attacker-controlled file path |

## Test plan

- [x] ut-1: `core.worktreeConfig` stripped from local config — **PASS**
- [x] ut-2: `init.templateDir` stripped from local config — **PASS**
- [x] ut-3: `submodule.evil.update` stripped from local config — **PASS**
- [x] ut-4: `blame.ignoreRevsFile` stripped from local config — **PASS**
- [x] man-1: Run `container/tests/attack-test.sh` section 41 inside the sandbox container — verify all three injection tests PASS
- [x] man-2: Verify normal git operations (`git status`, `git add`, `git commit`, `git log`, `git diff`, `git push`) still work correctly inside the container