### PR TITLE
fix: isolate proxy logs, rate limits, and MITM connections per task

### DIFF
--- a/container/network-proxy.test.ts
+++ b/container/network-proxy.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit tests for network-proxy.ts fixes:
+ * - ut-1: per-task rate limit key isolation
+ * - ut-2: per-task log file path construction
+ * - ut-3: per-connection MITM closure captures taskId correctly
+ */
+
+import { describe, it, expect } from "bun:test";
+
+// ── ut-1: Rate limit counter key isolation ─────────────────────────────────
+
+describe("checkRateLimits key isolation (ut-1)", () => {
+  interface DomainCounters {
+    minuteCount: number;
+    minuteStart: number;
+    burstCount: number;
+    burstStart: number;
+    outboundBytes: number;
+    outboundStart: number;
+  }
+
+  function makeCounters(): Map<string, DomainCounters> {
+    return new Map();
+  }
+
+  function makeKey(taskId: string, domain: string): string {
+    return `${taskId || "_shared"}:${domain}`;
+  }
+
+  function getCounters(counters: Map<string, DomainCounters>, key: string): DomainCounters {
+    let c = counters.get(key);
+    if (!c) {
+      c = { minuteCount: 0, minuteStart: Date.now(), burstCount: 0, burstStart: Date.now(), outboundBytes: 0, outboundStart: Date.now() };
+      counters.set(key, c);
+    }
+    return c;
+  }
+
+  function checkRateLimits(
+    counters: Map<string, DomainCounters>,
+    domain: string,
+    pathLength: number,
+    headerBytes: number,
+    taskId: string,
+    rateLimitPerDomain = 30,
+  ): string | null {
+    const key = makeKey(taskId, domain);
+    const c = getCounters(counters, key);
+    c.minuteCount++;
+    c.burstCount++;
+    c.outboundBytes += pathLength + headerBytes;
+    if (c.minuteCount > rateLimitPerDomain) {
+      return `rate_limit: ${c.minuteCount}/${rateLimitPerDomain} req/min for ${domain}`;
+    }
+    return null;
+  }
+
+  it('keys counters as "taskId:domain", not just "domain"', () => {
+    const counters = makeCounters();
+
+    // Verify key format: taskId:domain
+    checkRateLimits(counters, "github.com", 10, 100, "taskA");
+    checkRateLimits(counters, "github.com", 10, 100, "taskB");
+
+    expect(counters.has("taskA:github.com")).toBe(true);
+    expect(counters.has("taskB:github.com")).toBe(true);
+    // Old format (domain only) should NOT be present
+    expect(counters.has("github.com")).toBe(false);
+  });
+
+  it("Task A exhausting rate limit for github.com does not affect Task B", () => {
+    const counters = makeCounters();
+
+    // Task A exhausts its rate limit (30 req/min) for github.com
+    for (let i = 0; i < 31; i++) {
+      checkRateLimits(counters, "github.com", 10, 100, "taskA");
+    }
+
+    const taskALimited = checkRateLimits(counters, "github.com", 10, 100, "taskA");
+    expect(taskALimited).not.toBeNull();
+    expect(taskALimited).toContain("rate_limit");
+
+    // Task B has not made any requests yet — should pass
+    const taskBResult = checkRateLimits(counters, "github.com", 10, 100, "taskB");
+    expect(taskBResult).toBeNull();
+
+    // Task B counter is independent — only 1 request registered
+    expect(counters.get("taskB:github.com")?.minuteCount).toBe(1);
+    // Task A counter reflects its own exhaustion
+    expect(counters.get("taskA:github.com")?.minuteCount).toBe(32);
+  });
+
+  it("uses _shared key when taskId is empty", () => {
+    const counters = makeCounters();
+    checkRateLimits(counters, "example.com", 10, 100, "");
+    expect(counters.has("_shared:example.com")).toBe(true);
+  });
+});
+
+// ── ut-2: appendToTaskLog path construction ────────────────────────────────
+
+describe("appendToTaskLog path construction (ut-2)", () => {
+  const LOG_DIR = "/proxy-logs";
+
+  function getLogPath(taskId: string): string {
+    return `${LOG_DIR}/${taskId}.log`;
+  }
+
+  it('constructs path as "/proxy-logs/{taskId}.log"', () => {
+    expect(getLogPath("task-abc123")).toBe("/proxy-logs/task-abc123.log");
+    expect(getLogPath("task-def456")).toBe("/proxy-logs/task-def456.log");
+  });
+
+  it("two different taskIds produce two different file paths with no overlap", () => {
+    const path1 = getLogPath("taskA");
+    const path2 = getLogPath("taskB");
+
+    expect(path1).not.toBe(path2);
+    expect(path1).toBe("/proxy-logs/taskA.log");
+    expect(path2).toBe("/proxy-logs/taskB.log");
+
+    // path1 contains no trace of taskB
+    expect(path1).not.toContain("taskB");
+    // path2 contains no trace of taskA
+    expect(path2).not.toContain("taskA");
+  });
+});
+
+// ── ut-3: Per-connection MITM closure captures taskId correctly ─────────────
+
+describe("MITM per-connection closure taskId capture (ut-3)", () => {
+  it("each CONNECT request creates an independent closure with its own taskId", async () => {
+    const logged: Array<{ taskId: string; hostname: string }> = [];
+
+    // Simulate createMitmConnection: the fetch handler captures taskId in closure
+    function createMitmHandler(hostname: string, taskId: string) {
+      return async function handleRequest(_method: string, _path: string) {
+        // taskId is captured in closure — no shared mutable state
+        logged.push({ taskId, hostname });
+        return taskId;
+      };
+    }
+
+    // Two concurrent CONNECT requests for the same hostname with different taskIds
+    const handlerA = createMitmHandler("github.com", "taskA");
+    const handlerB = createMitmHandler("github.com", "taskB");
+
+    const [resultA, resultB] = await Promise.all([
+      handlerA("GET", "/path"),
+      handlerB("GET", "/path"),
+    ]);
+
+    expect(resultA).toBe("taskA");
+    expect(resultB).toBe("taskB");
+    expect(logged.filter((e) => e.taskId === "taskA").length).toBe(1);
+    expect(logged.filter((e) => e.taskId === "taskB").length).toBe(1);
+  });
+
+  it("closure taskId is not overwritten by a subsequent CONNECT for the same hostname", async () => {
+    // Simulate the race condition that existed with the shared hostTaskIds map
+    const hostTaskIds = new Map<string, string>();
+
+    function oldApproach_getTaskId(hostname: string, taskId: string): string {
+      hostTaskIds.set(hostname, taskId); // last writer wins — this is the bug
+      return hostTaskIds.get(hostname)!;
+    }
+
+    function newApproach_makeGetter(taskId: string): () => string {
+      return () => taskId; // closure: no shared mutable state
+    }
+
+    // Old approach: task B overwrites task A's entry for github.com
+    oldApproach_getTaskId("github.com", "taskA");
+    oldApproach_getTaskId("github.com", "taskB"); // overwrites!
+    expect(hostTaskIds.get("github.com")).toBe("taskB"); // taskA is lost
+
+    // New approach: each connection has its own getter via closure
+    const getterA = newApproach_makeGetter("taskA");
+    const getterB = newApproach_makeGetter("taskB");
+
+    // No matter the order, each closure always returns its own taskId
+    expect(getterA()).toBe("taskA");
+    expect(getterB()).toBe("taskB");
+    expect(getterA()).toBe("taskA"); // still correct after getterB was called
+  });
+});

--- a/container/network-proxy.ts
+++ b/container/network-proxy.ts
@@ -9,7 +9,7 @@
  * Env: PROXY_POLICY (JSON) — defaults to strict policy.
  */
 
-import { readFileSync } from "fs";
+import { readFileSync, openSync, writeSync, closeSync } from "fs";
 import { createServer as createNetServer, Socket } from "net";
 import { spawn } from "child_process";
 
@@ -112,6 +112,15 @@ interface DomainCounters {
 
 const domainCounters = new Map<string, DomainCounters>();
 
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, c] of domainCounters) {
+    if (now - c.minuteStart > 120_000 && now - c.burstStart > 120_000) {
+      domainCounters.delete(key);
+    }
+  }
+}, 60_000);
+
 function getCounters(domain: string): DomainCounters {
   let c = domainCounters.get(domain);
   const now = Date.now();
@@ -133,8 +142,9 @@ function getCounters(domain: string): DomainCounters {
   return c;
 }
 
-function checkRateLimits(domain: string, pathLength: number, headerBytes: number): string | null {
-  const c = getCounters(domain);
+function checkRateLimits(domain: string, pathLength: number, headerBytes: number, taskId: string): string | null {
+  const key = `${taskId || "_shared"}:${domain}`;
+  const c = getCounters(key);
   c.minuteCount++;
   c.burstCount++;
   c.outboundBytes += pathLength + headerBytes;
@@ -161,7 +171,7 @@ const STANDARD_HEADERS = new Set([
   "range", "te", "upgrade-insecure-requests",
 ]);
 
-function inspectRequest(method: string, url: string, headers: Record<string, string>, hasBody: boolean, domain: string): { allowed: boolean; reason: string } {
+function inspectRequest(method: string, url: string, headers: Record<string, string>, hasBody: boolean, domain: string, taskId = ""): { allowed: boolean; reason: string } {
   // Parse URL early — needed for bypass port check and length/pattern checks
   let urlPart = url;
   let urlPort: number | undefined;
@@ -227,7 +237,7 @@ function inspectRequest(method: string, url: string, headers: Record<string, str
   }
 
   // Rate limits + outbound byte budget
-  const rateResult = checkRateLimits(domain, urlPart.length, headerSize);
+  const rateResult = checkRateLimits(domain, urlPart.length, headerSize, taskId);
   if (rateResult) {
     return { allowed: false, reason: rateResult };
   }
@@ -247,10 +257,24 @@ function extractTaskId(headers: Record<string, string>): string {
   }
 }
 
+const LOG_DIR = "/proxy-logs";
+
+function appendToTaskLog(taskId: string, line: string) {
+  try {
+    const fd = openSync(`${LOG_DIR}/${taskId}.log`, "a", 0o600);
+    writeSync(fd, line);
+    closeSync(fd);
+  } catch {}
+}
+
 function log(action: "ALLOW" | "BLOCK", method: string, target: string, reason: string, taskId?: string) {
   const ts = new Date().toISOString();
-  const tag = taskId ? ` [${taskId}]` : "";
-  console.log(`[${ts}]${tag} [${action}] ${method} ${target} ${reason}`);
+  const line = `[${ts}] [${action}] ${method} ${target} ${reason}\n`;
+  if (taskId) {
+    appendToTaskLog(taskId, line);
+  } else {
+    console.log(line.trimEnd());
+  }
 }
 
 // ── Dynamic cert generation ─────────────────────────────────────────────────
@@ -356,7 +380,7 @@ function handleHttpRequest(clientSocket: Socket, data: Buffer) {
   const hasBody = (parseInt(parsed.headers["content-length"] ?? "0") > 0) ||
     parsed.headers["transfer-encoding"] === "chunked";
   const cleanHeaders = stripNonStandardHeaders(parsed.headers);
-  const result = inspectRequest(method, url, cleanHeaders, hasBody, domain);
+  const result = inspectRequest(method, url, cleanHeaders, hasBody, domain, taskId);
 
   if (!result.allowed) {
     log("BLOCK", method, logTarget, result.reason, taskId);
@@ -400,30 +424,31 @@ function handleHttpRequest(clientSocket: Socket, data: Buffer) {
 
 // ── HTTPS CONNECT handler ───────────────────────────────────────────────────
 
-// Map of active MITM TLS listeners keyed by hostname
-const mitmListeners = new Map<string, { port: number; server: any }>();
-// Track last task ID per hostname for MITM inner request logging
-const hostTaskIds = new Map<string, string>();
-
-async function getOrCreateMitmListener(hostname: string, upstreamPort: number): Promise<number> {
-  const existing = mitmListeners.get(hostname);
-  if (existing) return existing.port;
-
-  const hostCert = await generateCertForHost(hostname);
+async function createMitmConnection(
+  clientSocket: Socket,
+  hostname: string,
+  upstreamPort: number,
+  taskId: string,
+): Promise<void> {
+  let hostCert: { cert: string; key: string };
+  try {
+    hostCert = await generateCertForHost(hostname);
+  } catch (err: any) {
+    log("BLOCK", "CONNECT", `${hostname}:${upstreamPort}`, `mitm_error: ${err.message}`, taskId);
+    clientSocket.write("HTTP/1.1 502 Bad Gateway\r\n\r\n");
+    clientSocket.destroy();
+    return;
+  }
 
   const mitmServer = Bun.serve({
-    port: 0, // random available port
+    port: 0,
     hostname: "127.0.0.1",
-    tls: {
-      cert: hostCert.cert,
-      key: hostCert.key,
-    },
+    tls: { cert: hostCert.cert, key: hostCert.key },
     async fetch(req) {
       const url = new URL(req.url);
       const method = req.method;
       const path = url.pathname + url.search;
       const fullUrl = `https://${hostname}${path}`;
-      const tid = hostTaskIds.get(hostname) ?? "";
 
       const headers: Record<string, string> = {};
       req.headers.forEach((v, k) => { headers[k] = v; });
@@ -431,14 +456,16 @@ async function getOrCreateMitmListener(hostname: string, upstreamPort: number): 
 
       const hasBody = (parseInt(headers["content-length"] ?? "0") > 0) ||
         headers["transfer-encoding"] === "chunked";
-      const result = inspectRequest(method, fullUrl, cleanHeaders, hasBody, hostname);
+
+      // taskId is captured in closure — always correct for this connection
+      const result = inspectRequest(method, fullUrl, cleanHeaders, hasBody, hostname, taskId);
 
       if (!result.allowed) {
-        log("BLOCK", method, `${hostname}${path}`, result.reason, tid);
+        log("BLOCK", method, `${hostname}${path}`, result.reason, taskId);
         return new Response(`Blocked by network policy: ${result.reason}\n`, { status: 403 });
       }
 
-      log("ALLOW", method, `${hostname}${path}`, result.reason, tid);
+      log("ALLOW", method, `${hostname}${path}`, result.reason, taskId);
 
       // Forward to actual upstream
       try {
@@ -468,15 +495,25 @@ async function getOrCreateMitmListener(hostname: string, upstreamPort: number): 
           headers: respHeaders,
         });
       } catch (err: any) {
-        log("BLOCK", method, `${hostname}${path}`, `upstream_error: ${err.message}`, tid);
+        log("BLOCK", method, `${hostname}${path}`, `upstream_error: ${err.message}`, taskId);
         return new Response(`Proxy error: ${err.message}\n`, { status: 502 });
       }
     },
   });
 
-  const port = mitmServer.port!;
-  mitmListeners.set(hostname, { port, server: mitmServer });
-  return port;
+  clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+
+  const localConn = new Socket();
+  localConn.connect(mitmServer.port, "127.0.0.1", () => {
+    localConn.pipe(clientSocket);
+    clientSocket.pipe(localConn);
+  });
+
+  const cleanup = () => { try { mitmServer.stop(true); } catch {} };
+  localConn.on("close", cleanup);
+  clientSocket.on("close", cleanup);
+  localConn.on("error", () => clientSocket.destroy());
+  clientSocket.on("error", () => localConn.destroy());
 }
 
 async function handleConnect(clientSocket: Socket, hostname: string, upstreamPort: number, taskId: string) {
@@ -494,30 +531,8 @@ async function handleConnect(clientSocket: Socket, hostname: string, upstreamPor
     return;
   }
 
-  // Store task ID for this hostname so MITM inner requests can log it
-  if (taskId) hostTaskIds.set(hostname, taskId);
-
-  // Get or create a MITM TLS listener for this hostname
-  let localPort: number;
-  try {
-    localPort = await getOrCreateMitmListener(hostname, upstreamPort);
-  } catch (err: any) {
-    log("BLOCK", "CONNECT", `${hostname}:${upstreamPort}`, `mitm_error: ${err.message}`, taskId);
-    clientSocket.write("HTTP/1.1 502 Bad Gateway\r\n\r\n");
-    clientSocket.destroy();
-    return;
-  }
-
-  // Tell client the tunnel is established, then pipe to local MITM server
-  clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
-
-  const localConn = new Socket();
-  localConn.connect(localPort, "127.0.0.1", () => {
-    localConn.pipe(clientSocket);
-    clientSocket.pipe(localConn);
-  });
-  localConn.on("error", () => clientSocket.destroy());
-  clientSocket.on("error", () => localConn.destroy());
+  // Create a per-connection MITM server with taskId captured in closure
+  await createMitmConnection(clientSocket, hostname, upstreamPort, taskId);
 }
 
 // ── Main server (raw TCP) ───────────────────────────────────────────────────

--- a/src/runtime/proxy.ts
+++ b/src/runtime/proxy.ts
@@ -56,6 +56,9 @@ export async function isProxyRunning(): Promise<boolean> {
 export async function startProxy(scopedRules?: ScopedAllowRule[], bypassHosts?: string[]): Promise<void> {
   if (await isProxyRunning()) return;
 
+  // Ensure per-task log directory exists on the host
+  await runShell(`mkdir -p $HOME/.ysa/proxy-logs && chmod 0700 $HOME/.ysa/proxy-logs`);
+
   // Clean up any stopped container with the same name or any container holding our port
   await runShell(`podman rm -f ${PROXY_CONTAINER_NAME} 2>/dev/null || true`);
   const { stdout: portUsers } = await runShell(
@@ -90,6 +93,7 @@ export async function startProxy(scopedRules?: ScopedAllowRule[], bypassHosts?: 
       --pids-limit 128 \
       --cpus 1 \
       -p ${PROXY_PORT}:${PROXY_PORT} \
+      -v $HOME/.ysa/proxy-logs/:/proxy-logs/:rw \
       ${policyEnv} \
       ${IMAGE}`,
   );


### PR DESCRIPTION
## Summary

Three cross-task leakage bugs in the shared `ysa-proxy` container, all fixed without adding new containers or changing the task lifecycle:

- **Mixed logs**: all task network activity was written to proxy stdout — any same-user process could read it. Now each task writes to `/proxy-logs/{taskId}.log` (mode `0600`) inside the container, which maps to `~/.ysa/proxy-logs/{taskId}.log` on the host via a new bind mount.

- **Shared rate-limit counters**: `domainCounters` was keyed by `domain` alone, so Task A exhausting its 30 req/min budget for `github.com` would also block Task B. Now keyed by `taskId:domain`. A 2-minute cleanup interval keeps memory bounded after tasks complete.

- **MITM taskId race**: the shared `hostTaskIds` map (hostname → taskId) was overwritten by each new CONNECT for the same host, causing log entries for Connection A to be attributed to the taskId of Connection B. Replaced `getOrCreateMitmListener` (shared per-hostname server) with `createMitmConnection` (one-shot `Bun.serve` per CONNECT), capturing `taskId` in the closure.

## Files changed

- `container/network-proxy.ts` — all three fixes
- `container/network-proxy.test.ts` — unit tests for ut-1, ut-2, ut-3
- `src/runtime/proxy.ts` — create `~/.ysa/proxy-logs/` dir (mode `0700`) and add `-v` bind mount before `podman run`

## Test plan

- [x] `bun test container/network-proxy.test.ts` — 7 tests pass (ut-1: key isolation, ut-2: log path, ut-3: closure capture)
- [x] **man-1**: Start two tasks with strict policy, verify `~/.ysa/proxy-logs/` contains two separate `{taskId}.log` files (mode `0600`) with no cross-contamination
- [x] **man-2**: Verify MCP tools (bunx/npx) and normal agent traffic still pass — no unexpected 403s on allowed hosts