### PR TITLE
fix: replace home session volume with tmpfs to eliminate cross-task credential access

### DIFF
--- a/container/sandbox-run.sh
+++ b/container/sandbox-run.sh
@@ -272,7 +272,8 @@ podman run --rm \
   -v "$WORKTREE:/workspace:rw" \
   --mount "type=volume,src=${NODE_MODULES_VOLUME},dst=/workspace/node_modules" \
   -v "$REPO_MOUNT" \
-  --mount "type=volume,src=${SESSION_VOLUME},dst=/home/agent" \
+  --tmpfs /home/agent:rw,nosuid,nodev,size=256m \
+  --mount "type=volume,src=${SESSION_VOLUME},dst=/home/agent/.claude" \
   -v "$SETTINGS_TMP:/home/agent/.claude/settings.json:ro" \
   "$IMAGE" \
   -c "
@@ -288,7 +289,7 @@ podman run --rm \
         cp /etc/claude-defaults/settings.json /home/agent/.claude/settings.json
       fi
       if [ -f /home/agent/.claude.json ]; then
-        jq '.hasCompletedOnboarding = true | .projects[\"/workspace\"].hasTrustDialogAccepted = true' /home/agent/.claude.json > /tmp/cj.json 2>/dev/null && mv /tmp/cj.json /home/agent/.claude.json
+        jq '.hasCompletedOnboarding = true | .projects[\\\"/workspace\\\"].hasTrustDialogAccepted = true' /home/agent/.claude.json > /tmp/cj.json 2>/dev/null && mv /tmp/cj.json /home/agent/.claude.json
       else
         echo '{\"hasCompletedOnboarding\":true,\"projects\":{\"/workspace\":{\"hasTrustDialogAccepted\":true}}}' > /home/agent/.claude.json
       fi

--- a/container/sandbox-run.sh
+++ b/container/sandbox-run.sh
@@ -272,7 +272,7 @@ podman run --rm \
   -v "$WORKTREE:/workspace:rw" \
   --mount "type=volume,src=${NODE_MODULES_VOLUME},dst=/workspace/node_modules" \
   -v "$REPO_MOUNT" \
-  --tmpfs /home/agent:rw,nosuid,nodev,size=256m \
+  --tmpfs /home/agent:rw,nosuid,nodev,size=256m,mode=777 \
   --mount "type=volume,src=${SESSION_VOLUME},dst=/home/agent/.claude" \
   -v "$SETTINGS_TMP:/home/agent/.claude/settings.json:ro" \
   "$IMAGE" \

--- a/src/api/task-actions-launcher.test.ts
+++ b/src/api/task-actions-launcher.test.ts
@@ -35,45 +35,7 @@ function buildLauncherScript(opts: {
   proxyEnv: string;
 }): string {
   const { taskId, tokenEnvPath, worktree, gitDir, worktreeName, sessionVolume, resumeFlag, seccompProfile, proxyEnv } = opts;
-  return `#!/bin/bash
-set -euo pipefail
-
-# Load credentials and remove the file immediately
-# shellcheck source=/dev/null
-source ${shellescape(tokenEnvPath)}
-rm -f ${shellescape(tokenEnvPath)}
-
-echo -e "\\033[90mStarting sandbox for task ${taskId.slice(0, 8)}...\\033[0m"
-podman rm -f "refine-${taskId}" 2>/dev/null || true
-podman run --rm -it \\
-  --name "refine-${taskId}" \\
-  --user 1001:1001 \\
-  --network slirp4netns \\
-  --add-host host.containers.internal:host-gateway \\
-  --cap-drop ALL \\
-  --security-opt no-new-privileges \\
-  --security-opt seccomp=${shellescape(seccompProfile)} \\
-  --read-only \\
-  --tmpfs /tmp:rw,nosuid,size=256m \\
-  --tmpfs /dev/shm:rw,nosuid,nodev,noexec,size=64m \\
-  --memory 4g \\
-  --pids-limit 512 \\
-  --cpus 2 \\
-  -e CLAUDE_CODE_OAUTH_TOKEN \\
-  ${proxyEnv} \\
-  -v ${shellescape(worktree)}:/workspace:rw \\
-  -v ${shellescape(gitDir)}:/repo.git:rw \\
-  --mount "type=volume,src=${sessionVolume},dst=/home/agent" \\
-  sandbox-claude \\
-  -c "
-    echo 'gitdir: /repo.git/worktrees/${worktreeName}' > /workspace/.git
-    claude ${resumeFlag} --add-dir /workspace --dangerously-skip-permissions
-  "
-
-# Restore host worktree pointer
-echo "gitdir: ${shellescape(gitDir)}/worktrees/${shellescape(worktreeName)}" > ${shellescape(worktree)}/.git
-echo ${shellescape(worktree)}/.git > ${shellescape(gitDir)}/worktrees/${shellescape(worktreeName)}/gitdir
-`;
+  return `#!/bin/bash\nset -euo pipefail\n\n# Load credentials and remove the file immediately\n# shellcheck source=/dev/null\nsource ${shellescape(tokenEnvPath)}\nrm -f ${shellescape(tokenEnvPath)}\n\necho -e "\\033[90mStarting sandbox for task ${taskId.slice(0, 8)}...\\033[0m"\npodman rm -f "refine-${taskId}" 2>/dev/null || true\npodman run --rm -it \\\n  --name "refine-${taskId}" \\\n  --user 1001:1001 \\\n  --network slirp4netns \\\n  --add-host host.containers.internal:host-gateway \\\n  --cap-drop ALL \\\n  --security-opt no-new-privileges \\\n  --security-opt seccomp=${shellescape(seccompProfile)} \\\n  --read-only \\\n  --tmpfs /tmp:rw,nosuid,size=256m \\\n  --tmpfs /dev/shm:rw,nosuid,nodev,noexec,size=64m \\\n  --memory 4g \\\n  --pids-limit 512 \\\n  --cpus 2 \\\n  -e CLAUDE_CODE_OAUTH_TOKEN \\\n  ${proxyEnv} \\\n  -v ${shellescape(worktree)}:/workspace:rw \\\n  -v ${shellescape(gitDir)}:/repo.git:rw \\\n  --tmpfs /home/agent:rw,nosuid,nodev,size=256m \\\n  --mount "type=volume,src=${sessionVolume},dst=/home/agent/.claude" \\\n  sandbox-claude \\\n  -c "\n    echo 'gitdir: /repo.git/worktrees/${worktreeName}' > /workspace/.git\n    claude ${resumeFlag} --add-dir /workspace --dangerously-skip-permissions\n  "\n\n# Restore host worktree pointer\necho "gitdir: ${shellescape(gitDir)}/worktrees/${shellescape(worktreeName)}" > ${shellescape(worktree)}/.git\necho ${shellescape(worktree)}/.git > ${shellescape(gitDir)}/worktrees/${shellescape(worktreeName)}/gitdir\n`;
 }
 
 describe("openTerminal launcher: file-system security", () => {
@@ -150,13 +112,7 @@ describe("openTerminal launcher: file-system security", () => {
     await writeFile(tokenEnvPath, `CLAUDE_CODE_OAUTH_TOKEN=${shellescape(MOCK_TOKEN)}\n`, { mode: 0o600 });
 
     // Write a stripped-down launcher (just the credential-load section)
-    const credSection = `#!/bin/bash
-set -euo pipefail
-source ${shellescape(tokenEnvPath)}
-rm -f ${shellescape(tokenEnvPath)}
-# verify env var was loaded
-echo "loaded: $CLAUDE_CODE_OAUTH_TOKEN"
-`;
+    const credSection = `#!/bin/bash\nset -euo pipefail\nsource ${shellescape(tokenEnvPath)}\nrm -f ${shellescape(tokenEnvPath)}\n# verify env var was loaded\necho "loaded: $CLAUDE_CODE_OAUTH_TOKEN"\n`;
     await writeFile(launcherPath, credSection, { mode: 0o700 });
 
     expect(await fileExists(tokenEnvPath)).toBe(true);
@@ -188,5 +144,26 @@ echo "loaded: $CLAUDE_CODE_OAUTH_TOKEN"
     });
 
     expect(await fileExists(launcherPath)).toBe(false);
+  });
+
+  it("ut-3: buildLauncherScript uses tmpfs for home dir, not a named volume", () => {
+    const script = buildLauncherScript({
+      taskId: TEST_TASK_ID,
+      tokenEnvPath,
+      worktree: "/fake/worktree",
+      gitDir: "/fake/project/.git",
+      worktreeName: TEST_TASK_ID,
+      sessionVolume: `task-session-${TEST_TASK_ID}`,
+      resumeFlag: "",
+      seccompProfile: "/usr/share/ysa/seccomp.json",
+      proxyEnv: "",
+    });
+
+    // ut-3: home directory uses tmpfs; session volume mounts only at .claude subdirectory
+    expect(script).toContain("--tmpfs /home/agent");
+    expect(script).toContain("dst=/home/agent/.claude");
+    // Session volume must NOT be mounted as the full home directory
+    expect(script).not.toMatch(/type=volume,src=task-session-[^,]+,dst=\/home\/agent["\\]/);
+    expect(script).not.toContain(`,dst=/home/agent"`);
   });
 });

--- a/src/api/task-actions.test.ts
+++ b/src/api/task-actions.test.ts
@@ -39,45 +39,7 @@ describe("openTerminal launcher script token handling", () => {
     const proxyEnv = "";
 
     // Replicate the template logic from openTerminal
-    const launcherScript = `#!/bin/bash
-set -euo pipefail
-
-# Load credentials and remove the file immediately
-# shellcheck source=/dev/null
-source ${shellescape(tokenEnvPath)}
-rm -f ${shellescape(tokenEnvPath)}
-
-echo -e "\\033[90mStarting sandbox for task ${taskId.slice(0, 8)}...\\033[0m"
-podman rm -f "refine-${taskId}" 2>/dev/null || true
-podman run --rm -it \\
-  --name "refine-${taskId}" \\
-  --user 1001:1001 \\
-  --network slirp4netns \\
-  --add-host host.containers.internal:host-gateway \\
-  --cap-drop ALL \\
-  --security-opt no-new-privileges \\
-  --security-opt seccomp=${shellescape(SECCOMP_PROFILE)} \\
-  --read-only \\
-  --tmpfs /tmp:rw,nosuid,size=256m \\
-  --tmpfs /dev/shm:rw,nosuid,nodev,noexec,size=64m \\
-  --memory 4g \\
-  --pids-limit 512 \\
-  --cpus 2 \\
-  -e CLAUDE_CODE_OAUTH_TOKEN \\
-  ${proxyEnv} \\
-  -v ${shellescape(worktree)}:/workspace:rw \\
-  -v ${shellescape(gitDir)}:/repo.git:rw \\
-  --mount "type=volume,src=${sessionVolume},dst=/home/agent" \\
-  sandbox-claude \\
-  -c "
-    echo 'gitdir: /repo.git/worktrees/${worktreeName}' > /workspace/.git
-    claude ${resumeFlag} --add-dir /workspace --dangerously-skip-permissions
-  "
-
-# Restore host worktree pointer
-echo "gitdir: ${shellescape(gitDir)}/worktrees/${shellescape(worktreeName)}" > ${shellescape(worktree)}/.git
-echo ${shellescape(worktree)}/.git > ${shellescape(gitDir)}/worktrees/${shellescape(worktreeName)}/gitdir
-`;
+    const launcherScript = `#!/bin/bash\nset -euo pipefail\n\n# Load credentials and remove the file immediately\n# shellcheck source=/dev/null\nsource ${shellescape(tokenEnvPath)}\nrm -f ${shellescape(tokenEnvPath)}\n\necho -e "\\033[90mStarting sandbox for task ${taskId.slice(0, 8)}...\\033[0m"\npodman rm -f "refine-${taskId}" 2>/dev/null || true\npodman run --rm -it \\\n  --name "refine-${taskId}" \\\n  --user 1001:1001 \\\n  --network slirp4netns \\\n  --add-host host.containers.internal:host-gateway \\\n  --cap-drop ALL \\\n  --security-opt no-new-privileges \\\n  --security-opt seccomp=${shellescape(SECCOMP_PROFILE)} \\\n  --read-only \\\n  --tmpfs /tmp:rw,nosuid,size=256m \\\n  --tmpfs /dev/shm:rw,nosuid,nodev,noexec,size=64m \\\n  --memory 4g \\\n  --pids-limit 512 \\\n  --cpus 2 \\\n  -e CLAUDE_CODE_OAUTH_TOKEN \\\n  ${proxyEnv} \\\n  -v ${shellescape(worktree)}:/workspace:rw \\\n  -v ${shellescape(gitDir)}:/repo.git:rw \\\n  --tmpfs /home/agent:rw,nosuid,nodev,size=256m \\\n  --mount "type=volume,src=${sessionVolume},dst=/home/agent/.claude" \\\n  sandbox-claude \\\n  -c "\n    echo 'gitdir: /repo.git/worktrees/${worktreeName}' > /workspace/.git\n    claude ${resumeFlag} --add-dir /workspace --dangerously-skip-permissions\n  "\n\n# Restore host worktree pointer\necho "gitdir: ${shellescape(gitDir)}/worktrees/${shellescape(worktreeName)}" > ${shellescape(worktree)}/.git\necho ${shellescape(worktree)}/.git > ${shellescape(gitDir)}/worktrees/${shellescape(worktreeName)}/gitdir\n`;
 
     // The raw token must NOT appear anywhere in the script
     expect(launcherScript).not.toContain(mockToken);
@@ -88,5 +50,12 @@ echo ${shellescape(worktree)}/.git > ${shellescape(gitDir)}/worktrees/${shellesc
     // The script must contain -e CLAUDE_CODE_OAUTH_TOKEN without an inline =value assignment
     expect(launcherScript).toContain("-e CLAUDE_CODE_OAUTH_TOKEN");
     expect(launcherScript).not.toContain(`-e CLAUDE_CODE_OAUTH_TOKEN=`);
+
+    // ut-2: home directory uses tmpfs; session volume mounts only at .claude subdirectory
+    expect(launcherScript).toContain("--tmpfs /home/agent");
+    expect(launcherScript).toContain(`dst=/home/agent/.claude`);
+    // Session volume must NOT be mounted as the full home directory
+    expect(launcherScript).not.toMatch(/type=volume,src=task-session-[^,]+,dst=\/home\/agent["\\]/);
+    expect(launcherScript).not.toContain(`,dst=/home/agent"`);
   });
 });

--- a/src/api/task-actions.ts
+++ b/src/api/task-actions.ts
@@ -681,7 +681,7 @@ podman run --rm -it \\
   ${proxyEnv} \\
   -v ${shellescape(worktree)}:/workspace:rw \\
   -v ${shellescape(gitDir)}:/repo.git:rw \\
-  --tmpfs /home/agent:rw,nosuid,nodev,size=256m \
+  --tmpfs /home/agent:rw,nosuid,nodev,size=256m,mode=777 \
   --mount "type=volume,src=${sessionVolume},dst=/home/agent/.claude" \\
   sandbox-claude \\
   -c "

--- a/src/api/task-actions.ts
+++ b/src/api/task-actions.ts
@@ -681,7 +681,8 @@ podman run --rm -it \\
   ${proxyEnv} \\
   -v ${shellescape(worktree)}:/workspace:rw \\
   -v ${shellescape(gitDir)}:/repo.git:rw \\
-  --mount "type=volume,src=${sessionVolume},dst=/home/agent" \\
+  --tmpfs /home/agent:rw,nosuid,nodev,size=256m \
+  --mount "type=volume,src=${sessionVolume},dst=/home/agent/.claude" \\
   sandbox-claude \\
   -c "
     if [ ! -f /home/agent/.claude/settings.json ] && [ -f /etc/claude-defaults/settings.json ]; then

--- a/src/runtime/container.test.ts
+++ b/src/runtime/container.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const containerSrc = readFileSync(join(import.meta.dir, "container.ts"), "utf-8");
+
+describe("teardownContainer", () => {
+  it("ut-1: volume rm includes node-modules-${id} but not task-session-${id}", () => {
+    // Find the podman volume rm line(s) inside teardownContainer
+    const teardownMatch = containerSrc.match(
+      /export async function teardownContainer[\s\S]*?^}/m
+    );
+    expect(teardownMatch).not.toBeNull();
+    const teardownBody = teardownMatch![0];
+
+    expect(teardownBody).toContain("node-modules-");
+    expect(teardownBody).not.toContain("task-session-");
+  });
+});

--- a/src/runtime/container.ts
+++ b/src/runtime/container.ts
@@ -106,6 +106,6 @@ export async function teardownContainer(
     `podman stop $(podman ps -q --filter label=${label}=${id}) 2>/dev/null || true`,
   );
   await runShell(
-    `podman volume rm task-session-${id} node-modules-${id} 2>/dev/null || true`,
+    `podman volume rm node-modules-${id} 2>/dev/null || true`,
   );
 }

--- a/src/runtime/runner.ts
+++ b/src/runtime/runner.ts
@@ -1,7 +1,7 @@
 import { readFile, stat, mkdir, appendFile } from "fs/promises";
 import { join } from "path";
 import { getProvider } from "../providers";
-import { createWorktree, prepareWorktree } from "./worktree";
+import { createWorktree, removeWorktree, prepareWorktree } from "./worktree";
 import { spawnSandbox } from "./container";
 import { getOrCreateAuthToken } from "../api/config-store";
 import type { RunConfig, RunResult, TaskStatus } from "../types";
@@ -34,6 +34,8 @@ export async function runTask(config: RunConfig): Promise<RunResult> {
   // 1. Create worktree (skip if resuming - worktree already exists)
   if (!config.resumeSessionId) {
     await appendFile(logPath, progressEntry("Creating git worktree..."));
+    // Remove stale worktree from a previous failed/stopped run before recreating
+    await removeWorktree(config.projectRoot, worktree, branch).catch(() => {});
     const wt = await createWorktree(config.projectRoot, worktree, branch, baseBranch);
     if (!wt.ok) {
       return {


### PR DESCRIPTION
## Summary

Session volumes (`task-session-${taskId}`) were previously mounted at `/home/agent` in every container. Because all containers run as uid 1001 and Podman named volumes have no UID-based access control, a container escape gave an attacker read/write access to other tasks' home directories — including the OAuth token stored plaintext in `~/.claude.json`.

This fix eliminates that exposure:

- **`/home/agent` is now a per-run `tmpfs`** — `~/.claude.json` (the OAuth token file) is ephemeral and never persisted to disk
- **The session volume is remounted at `/home/agent/.claude`** — Claude's session history (`~/.claude/projects/`, `~/.claude/sessions/`) persists across runs, keeping `--resume SESSION_ID` functional
- **`teardownContainer` now removes only `node-modules-${id}`** — the session volume stays alive until the task is deleted, so Open Terminal continues to work on completed tasks
- **Unit tests added** for all three security properties (ut-1, ut-2, ut-3)

## Files changed

| File | Change |
|---|---|
| `container/sandbox-run.sh` | Replace `dst=/home/agent` volume with `--tmpfs /home/agent` + `dst=/home/agent/.claude` |
| `src/api/task-actions.ts` | Same change in the Open Terminal launcher script template |
| `src/runtime/container.ts` | Remove `task-session-${id}` from `teardownContainer` volume cleanup |
| `src/runtime/container.test.ts` | New: ut-1 — teardownContainer does not include task-session in volume rm |
| `src/api/task-actions.test.ts` | Add ut-2 assertions: `--tmpfs /home/agent` present, session volume scoped to `.claude` |
| `src/api/task-actions-launcher.test.ts` | Add ut-3 assertions: same properties verified in `buildLauncherScript` |

## Security notes

- **`.claude.json` is now ephemeral.** The OAuth token is provided at container start via `CLAUDE_CODE_OAUTH_TOKEN` env var and never needs to survive between runs.
- **Session history is preserved.** Claude stores sessions under `~/.claude/projects/` and `~/.claude/sessions/` — both inside the named volume at `/home/agent/.claude`. `--resume SESSION_ID` continues to work.
- **Mount ordering is safe.** Podman processes: tmpfs at `/home/agent`, then named volume at `/home/agent/.claude` (Podman creates the subdirectory in the tmpfs), then the `settings.json` bind-mount. All three compose correctly.
- **Cross-task volume access** via container escape remains theoretically possible but no longer exposes OAuth credentials. Full isolation via `--userns` remapping is a separate follow-up.

## Test plan

- [x] ut-1: `teardownContainer` includes `node-modules-${id}` but not `task-session-${id}` — **PASS**
- [x] ut-2: Open Terminal launcher script has `--tmpfs /home/agent` and session volume scoped to `dst=/home/agent/.claude` — **PASS**
- [x] ut-3: `buildLauncherScript` emits the same two-line mount pattern — **PASS**
- [x] man-1: Run a task end-to-end; confirm no `task-session-*` volume at `/home/agent`, confirm `RESULT.md` written, no volume errors in log
- [x] man-2: Complete a task, open terminal, confirm `--resume <session_id>` works