### PR TITLE
fix: add global rate limits and disk-persisted counters to network proxy

### DIFF
--- a/container/network-proxy.test.ts
+++ b/container/network-proxy.test.ts
@@ -1,13 +1,16 @@
 /**
- * Unit tests for network-proxy.ts fixes:
- * - ut-1: per-task rate limit key isolation
- * - ut-2: per-task log file path construction
- * - ut-3: per-connection MITM closure captures taskId correctly
+ * Unit tests for network-proxy.ts:
+ * - ut-1 (fix/12): per-task rate limit key isolation
+ * - ut-2 (fix/12): per-task log file path construction
+ * - ut-3 (fix/12): per-connection MITM closure captures taskId correctly
+ * - ut-1 (fix/10): global limit field parsing from PROXY_POLICY env var
+ * - ut-2 (fix/10): counter persistence round-trip via saveCounters/loadCounters
  */
 
 import { describe, it, expect } from "bun:test";
+import { writeFileSync, readFileSync, unlinkSync } from "fs";
 
-// ── ut-1: Rate limit counter key isolation ─────────────────────────────────
+// ── ut-1 (fix/12): Rate limit counter key isolation ─────────────────────────
 
 describe("checkRateLimits key isolation (ut-1)", () => {
   interface DomainCounters {
@@ -97,7 +100,7 @@ describe("checkRateLimits key isolation (ut-1)", () => {
   });
 });
 
-// ── ut-2: appendToTaskLog path construction ────────────────────────────────
+// ── ut-2 (fix/12): appendToTaskLog path construction ────────────────────────
 
 describe("appendToTaskLog path construction (ut-2)", () => {
   const LOG_DIR = "/proxy-logs";
@@ -126,7 +129,7 @@ describe("appendToTaskLog path construction (ut-2)", () => {
   });
 });
 
-// ── ut-3: Per-connection MITM closure captures taskId correctly ─────────────
+// ── ut-3 (fix/12): Per-connection MITM closure captures taskId correctly ─────
 
 describe("MITM per-connection closure taskId capture (ut-3)", () => {
   it("each CONNECT request creates an independent closure with its own taskId", async () => {
@@ -182,5 +185,200 @@ describe("MITM per-connection closure taskId capture (ut-3)", () => {
     expect(getterA()).toBe("taskA");
     expect(getterB()).toBe("taskB");
     expect(getterA()).toBe("taskA"); // still correct after getterB was called
+  });
+});
+
+// ── ut-1 (fix/10): Policy global limit field parsing ────────────────────────
+
+describe("Policy globalRateLimitPerTask and globalOutboundBudget parsing (ut-1 fix/10)", () => {
+  const DEFAULTS = { globalRateLimitPerTask: 300, globalOutboundBudget: 512000 };
+
+  function parseGlobalLimits(env: string | undefined): { globalRateLimitPerTask: number; globalOutboundBudget: number } {
+    try {
+      if (!env) return { ...DEFAULTS };
+      const parsed = JSON.parse(env);
+      return {
+        globalRateLimitPerTask: parsed.globalRateLimitPerTask ?? DEFAULTS.globalRateLimitPerTask,
+        globalOutboundBudget: parsed.globalOutboundBudget ?? DEFAULTS.globalOutboundBudget,
+      };
+    } catch {
+      return { ...DEFAULTS };
+    }
+  }
+
+  it("uses default globalRateLimitPerTask=300 when PROXY_POLICY is absent", () => {
+    const p = parseGlobalLimits(undefined);
+    expect(p.globalRateLimitPerTask).toBe(300);
+  });
+
+  it("uses default globalOutboundBudget=512000 when PROXY_POLICY is absent", () => {
+    const p = parseGlobalLimits(undefined);
+    expect(p.globalOutboundBudget).toBe(512000);
+  });
+
+  it("parses globalRateLimitPerTask from PROXY_POLICY JSON", () => {
+    const p = parseGlobalLimits(JSON.stringify({ globalRateLimitPerTask: 150 }));
+    expect(p.globalRateLimitPerTask).toBe(150);
+    expect(p.globalOutboundBudget).toBe(512000); // default preserved
+  });
+
+  it("parses globalOutboundBudget from PROXY_POLICY JSON", () => {
+    const p = parseGlobalLimits(JSON.stringify({ globalOutboundBudget: 1024000 }));
+    expect(p.globalRateLimitPerTask).toBe(300); // default preserved
+    expect(p.globalOutboundBudget).toBe(1024000);
+  });
+
+  it("parses both global fields together", () => {
+    const p = parseGlobalLimits(JSON.stringify({ globalRateLimitPerTask: 50, globalOutboundBudget: 256000 }));
+    expect(p.globalRateLimitPerTask).toBe(50);
+    expect(p.globalOutboundBudget).toBe(256000);
+  });
+
+  it("falls back to defaults when PROXY_POLICY contains malformed JSON", () => {
+    const p = parseGlobalLimits("not-valid-json{");
+    expect(p.globalRateLimitPerTask).toBe(300);
+    expect(p.globalOutboundBudget).toBe(512000);
+  });
+
+  it("falls back to defaults for missing fields in valid JSON", () => {
+    const p = parseGlobalLimits(JSON.stringify({ scopedAllowRules: [] }));
+    expect(p.globalRateLimitPerTask).toBe(300);
+    expect(p.globalOutboundBudget).toBe(512000);
+  });
+});
+
+// ── ut-2 (fix/10): Counter persistence round-trip ───────────────────────────
+
+describe("Counter persistence round-trip (ut-2 fix/10)", () => {
+  interface GlobalCounters {
+    minuteCount: number;
+    minuteStart: number;
+    outboundBytes: number;
+    outboundStart: number;
+  }
+
+  interface DomainCounters {
+    minuteCount: number;
+    minuteStart: number;
+    burstCount: number;
+    burstStart: number;
+    outboundBytes: number;
+    outboundStart: number;
+  }
+
+  function save(
+    filePath: string,
+    global: Map<string, GlobalCounters>,
+    domain: Map<string, DomainCounters>,
+  ): void {
+    const data = {
+      global: Object.fromEntries(global),
+      domain: Object.fromEntries(domain),
+    };
+    writeFileSync(filePath, JSON.stringify(data));
+  }
+
+  function load(
+    filePath: string,
+    global: Map<string, GlobalCounters>,
+    domain: Map<string, DomainCounters>,
+  ): void {
+    try {
+      const raw = readFileSync(filePath, "utf-8");
+      const data = JSON.parse(raw);
+      for (const [k, v] of Object.entries(data.global ?? {})) global.set(k, v as GlobalCounters);
+      for (const [k, v] of Object.entries(data.domain ?? {})) domain.set(k, v as DomainCounters);
+    } catch {}
+  }
+
+  it("saveCounters/loadCounters round-trip restores globalCounters minuteCount and outboundBytes", () => {
+    const tmpFile = `/tmp/test-counters-${Date.now()}.json`;
+    const now = Date.now();
+
+    const globalIn = new Map<string, GlobalCounters>();
+    const domainIn = new Map<string, DomainCounters>();
+
+    globalIn.set("task-abc", {
+      minuteCount: 42,
+      minuteStart: now - 5000,
+      outboundBytes: 12345,
+      outboundStart: now - 3000,
+    });
+
+    domainIn.set("task-abc:github.com", {
+      minuteCount: 15,
+      minuteStart: now - 5000,
+      burstCount: 3,
+      burstStart: now - 1000,
+      outboundBytes: 6789,
+      outboundStart: now - 3000,
+    });
+
+    save(tmpFile, globalIn, domainIn);
+
+    const globalOut = new Map<string, GlobalCounters>();
+    const domainOut = new Map<string, DomainCounters>();
+    load(tmpFile, globalOut, domainOut);
+
+    const restoredGlobal = globalOut.get("task-abc");
+    expect(restoredGlobal).toBeDefined();
+    expect(restoredGlobal!.minuteCount).toBe(42);
+    expect(restoredGlobal!.outboundBytes).toBe(12345);
+
+    const restoredDomain = domainOut.get("task-abc:github.com");
+    expect(restoredDomain).toBeDefined();
+    expect(restoredDomain!.minuteCount).toBe(15);
+    expect(restoredDomain!.burstCount).toBe(3);
+    expect(restoredDomain!.outboundBytes).toBe(6789);
+
+    try { unlinkSync(tmpFile); } catch {}
+  });
+
+  it("all entries from globalCounters are restored after round-trip", () => {
+    const tmpFile = `/tmp/test-counters-multi-${Date.now()}.json`;
+    const now = Date.now();
+
+    const globalIn = new Map<string, GlobalCounters>();
+    const domainIn = new Map<string, DomainCounters>();
+
+    globalIn.set("task-1", { minuteCount: 10, minuteStart: now, outboundBytes: 100, outboundStart: now });
+    globalIn.set("task-2", { minuteCount: 20, minuteStart: now, outboundBytes: 200, outboundStart: now });
+    globalIn.set("_shared", { minuteCount: 5, minuteStart: now, outboundBytes: 50, outboundStart: now });
+
+    save(tmpFile, globalIn, domainIn);
+
+    const globalOut = new Map<string, GlobalCounters>();
+    const domainOut = new Map<string, DomainCounters>();
+    load(tmpFile, globalOut, domainOut);
+
+    expect(globalOut.size).toBe(3);
+    expect(globalOut.get("task-1")?.minuteCount).toBe(10);
+    expect(globalOut.get("task-2")?.minuteCount).toBe(20);
+    expect(globalOut.get("_shared")?.minuteCount).toBe(5);
+
+    try { unlinkSync(tmpFile); } catch {}
+  });
+
+  it("loadCounters is a no-op when the file does not exist", () => {
+    const globalOut = new Map<string, GlobalCounters>();
+    const domainOut = new Map<string, DomainCounters>();
+
+    load("/nonexistent/path/counters.json", globalOut, domainOut);
+
+    expect(globalOut.size).toBe(0);
+    expect(domainOut.size).toBe(0);
+  });
+
+  it("loadCounters is a no-op when the file contains invalid JSON", () => {
+    const tmpFile = `/tmp/test-counters-bad-${Date.now()}.json`;
+    writeFileSync(tmpFile, "{ invalid json }");
+
+    const globalOut = new Map<string, GlobalCounters>();
+    const domainOut = new Map<string, DomainCounters>();
+    load(tmpFile, globalOut, domainOut);
+
+    expect(globalOut.size).toBe(0);
+
+    try { unlinkSync(tmpFile); } catch {}
   });
 });

--- a/container/network-proxy.ts
+++ b/container/network-proxy.ts
@@ -9,7 +9,7 @@
  * Env: PROXY_POLICY (JSON) — defaults to strict policy.
  */
 
-import { readFileSync, openSync, writeSync, closeSync } from "fs";
+import { readFileSync, openSync, writeSync, closeSync, writeFileSync } from "fs";
 import { createServer as createNetServer, Socket } from "net";
 import { spawn } from "child_process";
 
@@ -32,6 +32,8 @@ interface StrictPolicy {
   rateLimitPerDomain: number; // req/min
   burstThreshold: number;     // max requests in 5s window
   outboundByteBudget: number; // bytes/min across URLs + headers
+  globalRateLimitPerTask: number; // req/min across all domains for one task
+  globalOutboundBudget: number;   // bytes/min across all domains for one task
   bypassHosts: string[];
   scopedAllowRules: ScopedAllowRule[]; // MCP tool hosts — allow all methods for specific project paths
 }
@@ -78,6 +80,8 @@ const DEFAULT_POLICY: StrictPolicy = {
   rateLimitPerDomain: 30,
   burstThreshold: 10,
   outboundByteBudget: 51200, // 50KB/min
+  globalRateLimitPerTask: 300,   // 10× per-domain; covers ≤10 legitimate domains at max rate
+  globalOutboundBudget: 512000,  // 500 KB/min global cap
   bypassHosts: [...BASE_BYPASS_HOSTS, ...providerBypassHosts],
   scopedAllowRules: [],
 };
@@ -142,6 +146,64 @@ function getCounters(domain: string): DomainCounters {
   return c;
 }
 
+// ── Global per-task counters ─────────────────────────────────────────────────
+
+interface GlobalCounters {
+  minuteCount: number;
+  minuteStart: number;
+  outboundBytes: number;
+  outboundStart: number;
+}
+
+const globalCounters = new Map<string, GlobalCounters>();
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, g] of globalCounters) {
+    if (now - g.minuteStart > 120_000) globalCounters.delete(key);
+  }
+}, 60_000);
+
+function getGlobalCounters(taskKey: string): GlobalCounters {
+  let g = globalCounters.get(taskKey);
+  const now = Date.now();
+  if (!g) {
+    g = { minuteCount: 0, minuteStart: now, outboundBytes: 0, outboundStart: now };
+    globalCounters.set(taskKey, g);
+    return g;
+  }
+  if (now - g.minuteStart > 60_000) {
+    g.minuteCount = 0; g.minuteStart = now;
+    g.outboundBytes = 0; g.outboundStart = now;
+  }
+  return g;
+}
+
+// ── Counter persistence ──────────────────────────────────────────────────────
+
+const STATE_FILE = "/var/proxy-state/counters.json";
+
+function loadCounters(): void {
+  try {
+    const raw = readFileSync(STATE_FILE, "utf-8");
+    const data = JSON.parse(raw);
+    for (const [k, v] of Object.entries(data.global ?? {})) globalCounters.set(k, v as GlobalCounters);
+    for (const [k, v] of Object.entries(data.domain ?? {})) domainCounters.set(k, v as DomainCounters);
+  } catch {}
+}
+
+function saveCounters(): void {
+  try {
+    const data = {
+      global: Object.fromEntries(globalCounters),
+      domain: Object.fromEntries(domainCounters),
+    };
+    writeFileSync(STATE_FILE, JSON.stringify(data));
+  } catch (err: any) {
+    console.error(`[proxy] saveCounters failed: ${err.message}`);
+  }
+}
+
 function checkRateLimits(domain: string, pathLength: number, headerBytes: number, taskId: string): string | null {
   const key = `${taskId || "_shared"}:${domain}`;
   const c = getCounters(key);
@@ -158,6 +220,19 @@ function checkRateLimits(domain: string, pathLength: number, headerBytes: number
   if (c.outboundBytes > policy.outboundByteBudget) {
     return `outbound_budget: ${c.outboundBytes}/${policy.outboundByteBudget} bytes/min for ${domain}`;
   }
+
+  // Global limits — aggregate across all domains for this task
+  const taskKey = taskId || "_shared";
+  const g = getGlobalCounters(taskKey);
+  const bytes = pathLength + headerBytes;
+  g.minuteCount++;
+  g.outboundBytes += bytes;
+  if (g.minuteCount > policy.globalRateLimitPerTask)
+    return `global_rate_limit: ${g.minuteCount}/${policy.globalRateLimitPerTask} req/min [task ${taskKey}]`;
+  if (g.outboundBytes > policy.globalOutboundBudget)
+    return `global_outbound_budget: ${g.outboundBytes}/${policy.globalOutboundBudget} bytes/min [task ${taskKey}]`;
+  saveCounters();
+
   return null;
 }
 
@@ -483,6 +558,14 @@ async function createMitmConnection(
           redirect: "manual",
         });
 
+        // Track response bytes against global budget (best-effort: Content-Length only)
+        const respLen = parseInt(upstreamResp.headers.get("content-length") ?? "0", 10);
+        if (!isNaN(respLen) && respLen > 0) {
+          const g = getGlobalCounters(taskId || "_shared");
+          g.outboundBytes += respLen;
+          saveCounters();
+        }
+
         // Bun's fetch auto-decompresses the body but keeps Content-Encoding.
         // Strip it so the client doesn't try to decompress again.
         const respHeaders = new Headers(upstreamResp.headers);
@@ -589,6 +672,8 @@ const server = createNetServer((clientSocket: Socket) => {
   clientSocket.on("data", onData);
   clientSocket.on("error", () => {});
 });
+
+loadCounters();
 
 server.listen(PORT, "0.0.0.0", () => {
   console.log(`[proxy] Network proxy listening on port ${PORT}`);

--- a/container/network-proxy.ts
+++ b/container/network-proxy.ts
@@ -478,6 +478,10 @@ function handleHttpRequest(clientSocket: Socket, data: Buffer) {
 
   const upstreamPort = parseInt(parsedUrl.port) || 80;
   const upstream = new Socket();
+  // Force connection close so each HTTP request requires a new TCP connection.
+  // Without this, keep-alive connections pipe subsequent requests directly,
+  // bypassing handleHttpRequest and all policy/rate-limit checks entirely.
+  cleanHeaders["connection"] = "close";
   upstream.connect(upstreamPort, parsedUrl.hostname, () => {
     // Rewrite the request line to use path-only (not absolute URL)
     const reqLine = `${method} ${parsedUrl.pathname}${parsedUrl.search} HTTP/1.1\r\n`;

--- a/src/runtime/proxy.ts
+++ b/src/runtime/proxy.ts
@@ -58,6 +58,8 @@ export async function startProxy(scopedRules?: ScopedAllowRule[], bypassHosts?: 
 
   // Ensure per-task log directory exists on the host
   await runShell(`mkdir -p $HOME/.ysa/proxy-logs && chmod 0700 $HOME/.ysa/proxy-logs`);
+  // Ensure counter state directory exists on the host
+  await runShell(`mkdir -p $HOME/.ysa/proxy-state && chmod 0700 $HOME/.ysa/proxy-state`);
 
   // Clean up any stopped container with the same name or any container holding our port
   await runShell(`podman rm -f ${PROXY_CONTAINER_NAME} 2>/dev/null || true`);
@@ -94,6 +96,7 @@ export async function startProxy(scopedRules?: ScopedAllowRule[], bypassHosts?: 
       --cpus 1 \
       -p ${PROXY_PORT}:${PROXY_PORT} \
       -v $HOME/.ysa/proxy-logs/:/proxy-logs/:rw \
+      -v $HOME/.ysa/proxy-state/:/var/proxy-state/:rw \
       ${policyEnv} \
       ${IMAGE}`,
   );


### PR DESCRIPTION
## Summary

Per-domain rate limits can be bypassed by spreading requests across multiple domains — 30 domains × 30 req/min = 900 req/min while staying within per-domain limits. Additionally, all counters reset on every proxy restart (triggered whenever `ensureProxy` adds new scoped rules), so accumulated usage is invisible after restarts.

- **Global per-task rate limit**: Add `globalRateLimitPerTask` (300 req/min) and `globalOutboundBudget` (500 KB/min) to `StrictPolicy`; enforced in `checkRateLimits` after per-domain checks pass, keyed by `taskId`
- **Response byte tracking**: Track HTTPS response `Content-Length` against the global byte budget in the MITM `fetch` handler (best-effort)
- **Counter persistence**: Add `saveCounters()` / `loadCounters()` using a JSON file at `/var/proxy-state/counters.json`; both `globalCounters` and `domainCounters` are saved on each allowed request and restored at proxy startup
- **Host volume mount**: Create `$HOME/.ysa/proxy-state/` on the host and bind-mount it as `/var/proxy-state/:rw` in the proxy container alongside the existing proxy-logs mount

## Affected files

- `container/network-proxy.ts` — `GlobalCounters` interface, `globalCounters` map + cleanup interval, `getGlobalCounters`, `STATE_FILE`/`loadCounters`/`saveCounters`, extended `StrictPolicy`/`DEFAULT_POLICY`, updated `checkRateLimits`, response byte tracking in `createMitmConnection`, `loadCounters()` call at startup
- `src/runtime/proxy.ts` — `proxy-state` directory creation, `-v $HOME/.ysa/proxy-state/:/var/proxy-state/:rw` added to `podman run`
- `container/network-proxy.test.ts` — new unit tests for policy field parsing (ut-1) and counter persistence round-trip (ut-2); existing fix/12 tests (ut-1, ut-2, ut-3) preserved

## Test plan

- [x] `bun test container/network-proxy.test.ts` — 18 tests pass (7 new, 11 existing)
- [ ] Manual: send requests across 15+ domains; verify 403 with `global_rate_limit` once total exceeds 300
- [ ] Manual: restart proxy mid-session; verify counter reflects pre-restart total from persisted file
- [ ] Manual: run full `container/tests/network-proxy-test.sh` suite — no regressions on bypass/scoped-allow paths