### PR TITLE
fix: network logs empty on Linux

### DIFF
--- a/container/network-proxy.ts
+++ b/container/network-proxy.ts
@@ -504,7 +504,7 @@ async function createMitmConnection(
   clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
 
   const localConn = new Socket();
-  localConn.connect(mitmServer.port, "127.0.0.1", () => {
+  localConn.connect(mitmServer.port!, "127.0.0.1", () => {
     localConn.pipe(clientSocket);
     clientSocket.pipe(localConn);
   });

--- a/src/api/tasks.ts
+++ b/src/api/tasks.ts
@@ -4,6 +4,7 @@ import { getDb, schema } from "../db";
 import { eq, desc } from "drizzle-orm";
 import { readFile, stat, appendFile } from "fs/promises";
 import { join } from "path";
+import { homedir } from "os";
 import { getProvider } from "../providers";
 import type { ParsedLogEntry } from "../types";
 
@@ -84,13 +85,7 @@ async function scrapeProxyLogs(taskId: string, logPath: string): Promise<void> {
   }
 }
 
-async function getProxyLogs(taskId: string, logPath: string): Promise<ParsedLogEntry[]> {
-  await scrapeProxyLogs(taskId, logPath);
-
-  const netLog = networkLogPath(logPath);
-  if (!(await fileExists(netLog))) return [];
-
-  const raw = await readFile(netLog, "utf-8");
+function parseProxyLogLines(raw: string): ParsedLogEntry[] {
   return raw
     .split("\n")
     .filter((line) => line.trim())
@@ -108,6 +103,22 @@ async function getProxyLogs(taskId: string, logPath: string): Promise<ParsedLogE
         ts,
       };
     });
+}
+
+async function getProxyLogs(taskId: string, logPath: string): Promise<ParsedLogEntry[]> {
+  // Read directly from the bind-mounted per-task proxy log file.
+  // The proxy writes to /proxy-logs/{taskId}.log inside the container,
+  // which is bind-mounted from $HOME/.ysa/proxy-logs/ on the host.
+  const proxyLogFile = join(homedir(), ".ysa", "proxy-logs", `${taskId}.log`);
+  if (await fileExists(proxyLogFile)) {
+    return parseProxyLogLines(await readFile(proxyLogFile, "utf-8"));
+  }
+
+  // Fallback: legacy scraping via podman logs (used when bind mount isn't available)
+  await scrapeProxyLogs(taskId, logPath);
+  const netLog = networkLogPath(logPath);
+  if (!(await fileExists(netLog))) return [];
+  return parseProxyLogLines(await readFile(netLog, "utf-8"));
 }
 
 export const tasksRouter = router({


### PR DESCRIPTION
## Summary

- Network log section in the UI always showed empty on Linux because `scrapeProxyLogs` read from `podman logs ysa-proxy` (stdout), but the proxy writes per-task logs to files (`/proxy-logs/{taskId}.log`) — never to stdout
- On Linux with native rootless Podman, `podman logs` also defaults to journald which compounded the issue
- Fix `getProxyLogs` to read directly from the bind-mounted host path (`$HOME/.ysa/proxy-logs/{taskId}.log`) where the proxy actually writes, with the old scraping as a fallback
- Also fixes a pre-existing TS error in `container/network-proxy.ts`: `mitmServer.port` typed as `number | undefined` by Bun, added `!` assertion since the server is always running at that point

## Test plan

- [x] Run a task with `strict` network policy on Linux — network log section should show ALLOW/BLOCK entries
- [x] Verify same works on Mac (reads from direct file path, which is the same bind-mounted location)
- [x] `bun run typecheck` passes