### PR TITLE
fix: add 127.0.0.1 CORS origins and enable credentials

### DIFF
--- a/src/server/cors.test.ts
+++ b/src/server/cors.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "bun:test";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+
+const PORT = 4000;
+
+function makeApp() {
+  const app = new Hono();
+  app.use("/trpc/*", cors({
+    origin: [
+      `http://localhost:4001`,
+      `http://127.0.0.1:4001`,
+      `http://localhost:${PORT}`,
+      `http://127.0.0.1:${PORT}`,
+    ],
+    allowHeaders: ["Content-Type", "Authorization"],
+    credentials: true,
+  }));
+  app.get("/trpc/test", (c) => c.json({ ok: true }));
+  return app;
+}
+
+function preflight(app: Hono, origin: string) {
+  return app.request("/trpc/test", {
+    method: "OPTIONS",
+    headers: {
+      Origin: origin,
+      "Access-Control-Request-Method": "GET",
+      "Access-Control-Request-Headers": "Authorization",
+    },
+  });
+}
+
+describe("CORS middleware", () => {
+  it("ut-1: localhost:4001 receives matching origin and credentials header", async () => {
+    const app = makeApp();
+    const res = await preflight(app, "http://localhost:4001");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:4001");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  });
+
+  it("ut-2: 127.0.0.1:4001 receives matching origin and credentials header", async () => {
+    const app = makeApp();
+    const res = await preflight(app, "http://127.0.0.1:4001");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://127.0.0.1:4001");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  });
+
+  it("ut-3: localhost:4000 (production origin) receives matching origin and credentials header", async () => {
+    const app = makeApp();
+    const res = await preflight(app, "http://localhost:4000");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:4000");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  });
+
+  it("ut-4: untrusted origin does not receive a matching Access-Control-Allow-Origin header", async () => {
+    const app = makeApp();
+    const res = await preflight(app, "http://evil.example.com");
+    const allowOrigin = res.headers.get("Access-Control-Allow-Origin");
+    expect(allowOrigin).not.toBe("http://evil.example.com");
+  });
+});

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,8 +18,14 @@ const { port: PORT } = getServerConfig();
 const app = new Hono();
 
 app.use("/trpc/*", cors({
-  origin: [`http://localhost:4001`, `http://localhost:${PORT}`],
+  origin: [
+    `http://localhost:4001`,
+    `http://127.0.0.1:4001`,
+    `http://localhost:${PORT}`,
+    `http://127.0.0.1:${PORT}`,
+  ],
   allowHeaders: ["Content-Type", "Authorization"],
+  credentials: true,
 }));
 app.use("/trpc/*", requireLocalToken);
 app.use(


### PR DESCRIPTION
## Summary

- Extends the CORS `origin` allowlist on `/trpc/*` to include `127.0.0.1` variants (`http://127.0.0.1:4001` and `http://127.0.0.1:${PORT}`) alongside the existing `localhost` entries. Some browsers treat `localhost` and `127.0.0.1` as distinct origins, so both are required for reliable cross-origin handling.
- Adds `credentials: true` to emit `Access-Control-Allow-Credentials: true` in CORS responses, enabling cookie/auth-header sharing for credentialed requests.
- Adds `src/server/cors.test.ts` with four unit tests covering all allowed origins and verifying that untrusted origins are rejected.

## Test plan

- [x] `ut-1`: OPTIONS from `http://localhost:4001` → `Access-Control-Allow-Origin: http://localhost:4001`, `Access-Control-Allow-Credentials: true`
- [x] `ut-2`: OPTIONS from `http://127.0.0.1:4001` → matching origin header and credentials flag
- [x] `ut-3`: OPTIONS from `http://localhost:4000` (production port) → matching origin header and credentials flag
- [x] `ut-4`: OPTIONS from `http://evil.example.com` → no matching `Access-Control-Allow-Origin`
- [x] `man-1`: Start `bun run dev`, open dashboard at `http://localhost:4001`, confirm no CORS errors in console
- [x] `man-2`: Run `curl -si -H "Origin: http://evil.example.com" -H "Authorization: Bearer bad" http://localhost:4000/trpc/tasks.list | grep -i "access-control"` — confirm no `Access-Control-Allow-Origin` header is returned. (Browser `Origin` spoofing via fetch headers is not possible; `ut-4` covers the same property in unit tests.)