### PR TITLE
fix: add --connect-timeout 5 and reduce --max-time to 10s for PROMPT_URL fetch

### DIFF
--- a/container/sandbox-run.sh
+++ b/container/sandbox-run.sh
@@ -306,7 +306,7 @@ podman run --rm \
       *)
         if [ -n \"\$PROMPT_URL\" ]; then
           _progress 'Fetching prompt...'
-          PROMPT=\$(curl --max-time 30 -sf -H \"Authorization: Bearer \$PROMPT_TOKEN\" \"\$PROMPT_URL\")
+          PROMPT=\$(curl --max-time 10 --connect-timeout 5 -sf -H \"Authorization: Bearer \$PROMPT_TOKEN\" \"\$PROMPT_URL\")
           if [ -z \"\$PROMPT\" ]; then
             echo 'ERROR: Failed to fetch prompt from PROMPT_URL' >&2
             exit 1

--- a/src/container/sandbox-run.test.ts
+++ b/src/container/sandbox-run.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const sandboxRunPath = join(import.meta.dir, "../../container/sandbox-run.sh");
+const sandboxRunContent = readFileSync(sandboxRunPath, "utf-8");
+
+describe("sandbox-run.sh", () => {
+  it("ut-1: curl PROMPT_URL fetch has --max-time 10 and --connect-timeout 5", () => {
+    const curlLine = sandboxRunContent
+      .split("\n")
+      .find((line) => line.includes("PROMPT_URL") && line.includes("curl"));
+
+    expect(curlLine).toBeDefined();
+    expect(curlLine).toContain("--max-time 10");
+    expect(curlLine).toContain("--connect-timeout 5");
+  });
+});


### PR DESCRIPTION
## Summary

When `PROMPT_URL` is set, `sandbox-run.sh` fetches the prompt via `curl`. A previous commit added `--max-time 30`, but two gaps remained:

1. **Total timeout too long** — 30s gives a misbehaving server too much time to stall the container.
2. **No connection-phase timeout** — `--max-time` only bounds the total transfer once curl starts sending/receiving. A server that never completes the TCP handshake is bounded only by the OS connect timeout, which can be minutes.

This fix closes both gaps:

- `--connect-timeout 5` — bounds the TCP+TLS handshake phase independently
- `--max-time 10` — reduces the total transfer budget from 30s to 10s

The existing Bearer auth header is preserved unchanged.

## Files changed

| File | Change |
|---|---|
| `container/sandbox-run.sh` | Add `--connect-timeout 5`, reduce `--max-time` from `30` to `10` |
| `src/container/sandbox-run.test.ts` | New: ut-1 — static assertion that both timeout flags are present |

## Test plan

- [x] ut-1: grep `sandbox-run.sh` for curl line — assert `--max-time 10` and `--connect-timeout 5` both present — **PASS**
- [x] man-1: netcat listener test — container exits within ~15s with `ERROR: Failed to fetch prompt from PROMPT_URL`