### PR TITLE
fix: serialize git worktree creation with per-project file lock

### DIFF
--- a/src/runtime/worktree.test.ts
+++ b/src/runtime/worktree.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "path";
+import { mkdtemp, rm, mkdir } from "fs/promises";
+import { tmpdir } from "os";
+import { withFileLock, createWorktree } from "./worktree";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "worktree-test-"));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("withFileLock", () => {
+  it("ut-1: rejects with timeout error when lock cannot be acquired within timeoutMs", async () => {
+    const lockPath = join(tmpDir, "test.lock");
+
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    // Acquire the lock and hold it indefinitely
+    const holder = withFileLock(lockPath, () => held);
+
+    // Give the holder time to acquire the lock
+    await Bun.sleep(50);
+
+    // A concurrent acquisition with a short timeout must reject
+    await expect(
+      withFileLock(lockPath, async () => "second", 100),
+    ).rejects.toThrow("Could not acquire worktree lock after 100ms");
+
+    // Release the original holder
+    release();
+    await holder;
+  });
+});
+
+describe("createWorktree", () => {
+  it("ut-2: concurrent calls create the initial commit exactly once", async () => {
+    const repoDir = join(tmpDir, "repo");
+    await mkdir(repoDir, { recursive: true });
+
+    // Initialize a git repo with no commits
+    const initProc = Bun.spawn(
+      ["bash", "-c", "git init && git config user.email test@test.com && git config user.name Test"],
+      { cwd: repoDir, stdout: "pipe", stderr: "pipe" },
+    );
+    await initProc.exited;
+
+    const wt1 = join(tmpDir, "wt1");
+    const wt2 = join(tmpDir, "wt2");
+
+    // Run both concurrently — the lock ensures only one initial commit is created
+    const [r1, r2] = await Promise.all([
+      createWorktree(repoDir, wt1, "branch-task-1"),
+      createWorktree(repoDir, wt2, "branch-task-2"),
+    ]);
+
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+
+    // Verify exactly one initial commit exists
+    const logProc = Bun.spawn(["git", "log", "--oneline"], {
+      cwd: repoDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const log = await new Response(logProc.stdout).text();
+    await logProc.exited;
+
+    const commits = log.trim().split("\n").filter(Boolean);
+    expect(commits).toHaveLength(1);
+  });
+});

--- a/src/runtime/worktree.ts
+++ b/src/runtime/worktree.ts
@@ -1,4 +1,4 @@
-import { stat, readFile, mkdir, writeFile } from "fs/promises";
+import { stat, readFile, mkdir, writeFile, open, unlink } from "fs/promises";
 import { join } from "path";
 
 async function fileExists(path: string): Promise<boolean> {
@@ -27,41 +27,74 @@ async function runShell(
   return { ok: exitCode === 0, stdout: stdout.trim(), stderr: stderr.trim() };
 }
 
+export async function withFileLock<T>(
+  lockPath: string,
+  fn: () => Promise<T>,
+  timeoutMs = 10_000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 50;
+  while (true) {
+    try {
+      const fd = await open(lockPath, "wx");
+      try {
+        return await fn();
+      } finally {
+        await fd.close();
+        await unlink(lockPath).catch(() => {});
+      }
+    } catch (err: any) {
+      if (err.code !== "EEXIST") throw err;
+      if (Date.now() >= deadline) {
+        throw new Error(`Could not acquire worktree lock after ${timeoutMs}ms: ${lockPath}`);
+      }
+      await Bun.sleep(delay);
+      delay = Math.min(delay * 2, 1_000);
+    }
+  }
+}
+
 export async function createWorktree(
   projectRoot: string,
   worktreePath: string,
   branch: string,
   baseBranch?: string,
 ): Promise<{ ok: boolean; error?: string }> {
-  // Ensure the repo has at least one commit — worktrees require a valid HEAD
-  const headCheck = await runShell(`git -C ${projectRoot} rev-parse HEAD`);
-  if (!headCheck.ok) {
-    const init = await runShell(
-      `git -C ${projectRoot} -c user.email="ysa@localhost" -c user.name="ysa" commit --allow-empty -m "init"`,
+  const ysaDir = join(projectRoot, ".ysa");
+  await mkdir(ysaDir, { recursive: true });
+  const lockPath = join(ysaDir, "worktree.lock");
+
+  return withFileLock(lockPath, async () => {
+    // Ensure the repo has at least one commit — worktrees require a valid HEAD
+    const headCheck = await runShell(`git -C ${projectRoot} rev-parse HEAD`);
+    if (!headCheck.ok) {
+      const init = await runShell(
+        `git -C ${projectRoot} -c user.email="ysa@localhost" -c user.name="ysa" commit --allow-empty -m "init"`,
+      );
+      if (!init.ok) return { ok: false, error: `Failed to create initial commit: ${init.stderr}` };
+    }
+
+    // Verify baseBranch exists — if not (e.g. fresh repo with different default branch), ignore it
+    let resolvedBase = "";
+    if (baseBranch) {
+      const refCheck = await runShell(`git -C ${projectRoot} rev-parse --verify ${baseBranch}`);
+      if (refCheck.ok) resolvedBase = ` ${baseBranch}`;
+    }
+
+    // Create new branch, optionally based on a specific branch
+    let result = await runShell(
+      `git -C ${projectRoot} worktree add ${worktreePath} -b ${branch}${resolvedBase}`,
     );
-    if (!init.ok) return { ok: false, error: `Failed to create initial commit: ${init.stderr}` };
-  }
+    if (result.ok) return { ok: true };
 
-  // Verify baseBranch exists — if not (e.g. fresh repo with different default branch), ignore it
-  let resolvedBase = "";
-  if (baseBranch) {
-    const refCheck = await runShell(`git -C ${projectRoot} rev-parse --verify ${baseBranch}`);
-    if (refCheck.ok) resolvedBase = ` ${baseBranch}`;
-  }
+    // Branch may already exist — try without -b
+    result = await runShell(
+      `git -C ${projectRoot} worktree add ${worktreePath} ${branch}`,
+    );
+    if (result.ok) return { ok: true };
 
-  // Create new branch, optionally based on a specific branch
-  let result = await runShell(
-    `git -C ${projectRoot} worktree add ${worktreePath} -b ${branch}${resolvedBase}`,
-  );
-  if (result.ok) return { ok: true };
-
-  // Branch may already exist — try without -b
-  result = await runShell(
-    `git -C ${projectRoot} worktree add ${worktreePath} ${branch}`,
-  );
-  if (result.ok) return { ok: true };
-
-  return { ok: false, error: result.stderr };
+    return { ok: false, error: result.stderr };
+  });
 }
 
 export async function removeWorktree(


### PR DESCRIPTION
## Problem

`createWorktree` performs a non-atomic sequence of git operations:

1. `git rev-parse HEAD` — check if the repo has any commits
2. `git commit --allow-empty -m "init"` — create the initial commit if not
3. `git rev-parse --verify <baseBranch>` — verify the base branch
4. `git worktree add` — create the worktree

When two tasks start concurrently against the same repository, this sequence can interleave. The most critical race: both callers observe a missing HEAD before either creates the initial commit, so both attempt `commit --allow-empty`. This results in either two "init" commits or unexpected failures in the second caller.

## Fix

Wraps the entire body of `createWorktree` in `withFileLock` — a per-project file lock implemented with `open(path, "wx")` (O_EXCL semantics: atomic on all POSIX systems, fails with EEXIST if the file already exists) and exponential-backoff polling.

- **Lock path**: `<projectRoot>/.ysa/worktree.lock` — scoped per project, so concurrent tasks on *different* projects are unaffected
- **Timeout**: 10 s default — enough for slow git operations on large repos, short enough to surface real deadlocks
- **Cleanup**: deleted in a `finally` block; stale locks on crash are acceptable and removable manually
- **No new dependencies**: built entirely on `fs/promises` primitives and `Bun.sleep`

`removeWorktree` is not locked — it operates on a unique-per-task branch/path and cannot conflict with `createWorktree`.

## Changes

| File | Change |
|---|---|
| `src/runtime/worktree.ts` | Add `open` + `unlink` to imports; add exported `withFileLock` helper; wrap `createWorktree` body in file lock |
| `src/runtime/worktree.test.ts` | New: ut-1 (lock timeout), ut-2 (concurrent calls create one initial commit) |

## Test plan

- [x] ut-1: `withFileLock` rejects with timeout error when lock is already held — **PASS**
- [x] ut-2: two concurrent `createWorktree` calls on a fresh repo produce exactly one initial commit — **PASS**
- [x] man-1: start two tasks simultaneously via the web UI on a fresh git repo; verify both reach running status, each gets its own worktree, no lock or worktree errors in logs