### PR TITLE
feat: add configurable concurrent task limit and disk space pre-flight check

### DIFF
--- a/client/Setup.tsx
+++ b/client/Setup.tsx
@@ -37,6 +37,7 @@ export function Setup({ onComplete, onClose }: SetupProps) {
   const [model, setModel] = useState("claude-sonnet-4-6");
   const [networkPolicy, setNetworkPolicy] = useState<"none" | "strict">("strict");
   const [port, setPort] = useState("4000");
+  const [maxConcurrentTasks, setMaxConcurrentTasks] = useState("10");
   const [anthropicKey, setAnthropicKey] = useState("");
   const [mistralKey, setMistralKey] = useState("");
   const [anthropicKeyChanged, setAnthropicKeyChanged] = useState(false);
@@ -49,6 +50,7 @@ export function Setup({ onComplete, onClose }: SetupProps) {
     if (currentConfig.project_root) setProjectRoot(currentConfig.project_root);
     if (currentConfig.default_network_policy) setNetworkPolicy(currentConfig.default_network_policy as "none" | "strict");
     if (currentConfig.port) setPort(String(currentConfig.port));
+    if (currentConfig.max_concurrent_tasks) setMaxConcurrentTasks(String(currentConfig.max_concurrent_tasks));
     if (currentConfig.default_model) {
       const matchedProvider = Object.entries(MODELS_BY_PROVIDER).find(([, models]) =>
         models.some((m) => m.id === currentConfig.default_model)
@@ -82,6 +84,11 @@ export function Setup({ onComplete, onClose }: SetupProps) {
       setError("Port must be between 1024 and 65535");
       return;
     }
+    const parsedMaxConcurrent = parseInt(maxConcurrentTasks);
+    if (maxConcurrentTasks && (isNaN(parsedMaxConcurrent) || parsedMaxConcurrent < 1 || parsedMaxConcurrent > 100)) {
+      setError("Max concurrent tasks must be between 1 and 100");
+      return;
+    }
     if (anthropicKeyChanged && anthropicKey.trim()) {
       await setApiKey.mutateAsync({ provider: "anthropic", value: anthropicKey.trim() });
     }
@@ -93,6 +100,7 @@ export function Setup({ onComplete, onClose }: SetupProps) {
       default_model: model || null,
       default_network_policy: networkPolicy,
       port: port ? parsedPort : null,
+      max_concurrent_tasks: maxConcurrentTasks ? parsedMaxConcurrent : undefined,
     });
   };
 
@@ -120,7 +128,7 @@ export function Setup({ onComplete, onClose }: SetupProps) {
             disabled={pickDirectory.isPending}
             className="shrink-0 px-3.5 py-2.5 bg-bg-inset border border-border rounded-lg text-[12px] text-text-muted hover:text-text-primary hover:border-border-bright transition-all cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {pickDirectory.isPending ? "…" : "Browse"}
+            {pickDirectory.isPending ? "\u2026" : "Browse"}
           </button>
         </div>
         <p className="text-[12px] text-text-muted mt-1.5">Select an existing directory or create one first. Worktrees will be created under <span className="font-mono">.ysa/worktrees/</span> inside it.</p>
@@ -173,7 +181,7 @@ export function Setup({ onComplete, onClose }: SetupProps) {
           ))}
         </div>
         <p className="text-[12px] text-text-muted mt-1.5">
-          {networkPolicy === "none" ? "Full internet access inside the container." : "All traffic inspected via proxy — GET-only, entropy detection, rate limits."}
+          {networkPolicy === "none" ? "Full internet access inside the container." : "All traffic inspected via proxy \u2014 GET-only, entropy detection, rate limits."}
         </p>
       </div>
 
@@ -184,13 +192,13 @@ export function Setup({ onComplete, onClose }: SetupProps) {
         <div className="space-y-4">
           <div>
             <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-              Anthropic API key <span className="text-text-faint font-normal">(optional — only if not using OAuth)</span>
+              Anthropic API key <span className="text-text-faint font-normal">(optional \u2014 only if not using OAuth)</span>
             </label>
             <input
               type="password"
               value={anthropicKey}
               onChange={(e) => { setAnthropicKey(e.target.value); setAnthropicKeyChanged(true); }}
-              placeholder={currentConfig?.has_anthropic_key ? "Key configured — enter new value to update" : "sk-ant-..."}
+              placeholder={currentConfig?.has_anthropic_key ? "Key configured \u2014 enter new value to update" : "sk-ant-..."}
               className="w-full bg-bg-inset border border-border rounded-lg px-3.5 py-2.5 text-[13px] text-text-primary placeholder-text-faint focus:outline-none focus:border-primary/40 focus:ring-1 focus:ring-primary/20 transition-all font-mono"
             />
           </div>
@@ -203,14 +211,14 @@ export function Setup({ onComplete, onClose }: SetupProps) {
               type="password"
               value={mistralKey}
               onChange={(e) => { setMistralKey(e.target.value); setMistralKeyChanged(true); }}
-              placeholder={currentConfig?.has_mistral_key ? "Key configured — enter new value to update" : "••••••••••••••••"}
+              placeholder={currentConfig?.has_mistral_key ? "Key configured \u2014 enter new value to update" : "\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022"}
               className="w-full bg-bg-inset border border-border rounded-lg px-3.5 py-2.5 text-[13px] text-text-primary placeholder-text-faint focus:outline-none focus:border-primary/40 focus:ring-1 focus:ring-primary/20 transition-all font-mono"
             />
           </div>
         </div>
       </div>
 
-      {/* Port */}
+      {/* Port + concurrency */}
       <div className="border-t border-border pt-1">
         <p className="text-[11px] font-medium text-text-faint uppercase tracking-wide mb-4">Server</p>
         <div>
@@ -226,6 +234,21 @@ export function Setup({ onComplete, onClose }: SetupProps) {
             className="w-32 bg-bg-inset border border-border rounded-lg px-3.5 py-2.5 text-[13px] text-text-primary focus:outline-none focus:border-primary/40 focus:ring-1 focus:ring-primary/20 transition-all font-mono"
           />
           {isSettings && <p className="text-[12px] text-text-muted mt-1.5">Restart the server after changing the port.</p>}
+        </div>
+
+        <div className="mt-4">
+          <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+            Max concurrent tasks <span className="text-text-faint font-normal">(default: 10)</span>
+          </label>
+          <input
+            type="number"
+            value={maxConcurrentTasks}
+            onChange={(e) => setMaxConcurrentTasks(e.target.value)}
+            min={1}
+            max={100}
+            className="w-32 bg-bg-inset border border-border rounded-lg px-3.5 py-2.5 text-[13px] text-text-primary focus:outline-none focus:border-primary/40 focus:ring-1 focus:ring-primary/20 transition-all font-mono"
+          />
+          <p className="text-[12px] text-text-muted mt-1.5">Maximum number of tasks that can run simultaneously (1\u2013100).</p>
         </div>
       </div>
 
@@ -250,7 +273,7 @@ export function Setup({ onComplete, onClose }: SetupProps) {
     </form>
   );
 
-  // ── Settings modal ──────────────────────────────────────────────────────────
+  // \u2500\u2500 Settings modal \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
   if (isSettings) {
     return (
       <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 backdrop-blur-sm overflow-y-auto py-10">
@@ -271,7 +294,7 @@ export function Setup({ onComplete, onClose }: SetupProps) {
     );
   }
 
-  // ── First-run full-screen ───────────────────────────────────────────────────
+  // \u2500\u2500 First-run full-screen \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
   return (
     <div className="min-h-screen bg-bg flex items-start justify-center overflow-y-auto py-16">
       <div className="w-full max-w-xl px-4">
@@ -291,19 +314,19 @@ export function Setup({ onComplete, onClose }: SetupProps) {
             <div className="space-y-3">
               {!deps.git && (
                 <div className="flex items-start gap-3">
-                  <span className="text-err mt-0.5">✕</span>
+                  <span className="text-err mt-0.5">\u2715</span>
                   <div>
                     <p className="text-[14px] font-medium text-text-primary font-mono">git</p>
-                    <p className="text-[13px] text-text-muted">Required for worktree isolation between tasks. <a href="https://git-scm.com/downloads" target="_blank" rel="noreferrer" className="text-primary hover:underline">Installation guide →</a></p>
+                    <p className="text-[13px] text-text-muted">Required for worktree isolation between tasks. <a href="https://git-scm.com/downloads" target="_blank" rel="noreferrer" className="text-primary hover:underline">Installation guide \u2192</a></p>
                   </div>
                 </div>
               )}
               {!deps.podman && (
                 <div className="flex items-start gap-3">
-                  <span className="text-err mt-0.5">✕</span>
+                  <span className="text-err mt-0.5">\u2715</span>
                   <div>
                     <p className="text-[14px] font-medium text-text-primary font-mono">podman</p>
-                    <p className="text-[13px] text-text-muted">Required to run sandboxed containers. <a href="https://podman.io/docs/installation" target="_blank" rel="noreferrer" className="text-primary hover:underline">Installation guide →</a></p>
+                    <p className="text-[13px] text-text-muted">Required to run sandboxed containers. <a href="https://podman.io/docs/installation" target="_blank" rel="noreferrer" className="text-primary hover:underline">Installation guide \u2192</a></p>
                   </div>
                 </div>
               )}

--- a/src/api/config-store.ts
+++ b/src/api/config-store.ts
@@ -11,6 +11,7 @@ export type AppConfig = {
   anthropic_api_key: string | null;
   mistral_api_key: string | null;
   auth_token: string | null;
+  max_concurrent_tasks: number;
   has_anthropic_key?: boolean;
   has_mistral_key?: boolean;
 };
@@ -18,7 +19,7 @@ export type AppConfig = {
 export function getConfig(): AppConfig {
   const db = getDb();
   const row = db.select().from(schema.config).where(eq(schema.config.id, 1)).get();
-  return row ?? { project_root: null, default_model: null, default_network_policy: "none", preferred_terminal: null, port: null, anthropic_api_key: null, mistral_api_key: null, auth_token: null };
+  return row ?? { project_root: null, default_model: null, default_network_policy: "none", preferred_terminal: null, port: null, anthropic_api_key: null, mistral_api_key: null, auth_token: null, max_concurrent_tasks: 10 };
 }
 
 export function setConfig(updates: Partial<AppConfig>) {

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -54,6 +54,7 @@ export const configRouter = router({
         default_network_policy: z.enum(["none", "strict"]).optional(),
         preferred_terminal: z.string().nullable().optional(),
         port: z.number().int().min(1024).max(65535).nullable().optional(),
+        max_concurrent_tasks: z.number().int().min(1).max(100).optional(),
       }),
     )
     .mutation(async ({ input }) => {

--- a/src/api/task-actions.test.ts
+++ b/src/api/task-actions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { shellescape } from "./task-actions";
+import { shellescape, assertConcurrencyLimit, assertDiskSpace } from "./task-actions";
 import { join } from "path";
 
 describe("shellescape", () => {
@@ -21,6 +21,36 @@ describe("shellescape", () => {
 
   it("ut-1: escapes multiple embedded single quotes", () => {
     expect(shellescape("a'b'c")).toBe("'a'\\''b'\\''c'");
+  });
+});
+
+describe("assertConcurrencyLimit", () => {
+  it("ut-3: does not throw when count is below limit", () => {
+    expect(() => assertConcurrencyLimit(3, 10)).not.toThrow();
+  });
+  it("ut-3: does not throw when count equals limit minus one", () => {
+    expect(() => assertConcurrencyLimit(9, 10)).not.toThrow();
+  });
+  it("ut-3: throws when count equals limit", () => {
+    expect(() => assertConcurrencyLimit(10, 10)).toThrow("Too many active tasks");
+  });
+  it("ut-3: throws when count exceeds limit", () => {
+    expect(() => assertConcurrencyLimit(15, 10)).toThrow("Too many active tasks");
+  });
+});
+
+describe("assertDiskSpace", () => {
+  it("ut-4: does not throw when space is above minimum", () => {
+    expect(() => assertDiskSpace(2_000_000, 512)).not.toThrow();
+  });
+  it("ut-4: does not throw at exactly the threshold", () => {
+    expect(() => assertDiskSpace(512 * 1024, 512)).not.toThrow();
+  });
+  it("ut-4: throws when space is below minimum", () => {
+    expect(() => assertDiskSpace(256 * 1024, 512)).toThrow("Insufficient disk space");
+  });
+  it("ut-4: throws with correct available MB in message", () => {
+    expect(() => assertDiskSpace(100 * 1024, 512)).toThrow("100 MB available");
   });
 });
 

--- a/src/api/task-actions.ts
+++ b/src/api/task-actions.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { router, publicProcedure } from "./init";
 import { getDb, schema } from "../db";
-import { eq } from "drizzle-orm";
+import { eq, or, count } from "drizzle-orm";
 import { writeFile, readFile, stat, unlink, mkdir } from "fs/promises";
 import { join } from "path";
 import { runTask } from "../runtime/runner";
@@ -10,12 +10,63 @@ import { removeWorktree } from "../runtime/worktree";
 import { getProvider } from "../providers";
 import { ensureProxy } from "../runtime/proxy";
 import type { ScopedAllowRule } from "../runtime/proxy";
-import { getServerConfig, getOrCreateAuthToken } from "./config-store";
+import { getServerConfig, getOrCreateAuthToken, getConfig } from "./config-store";
 import type { RunConfig } from "../types";
 import { writeAuditLog } from "../lib/audit";
 
+const MIN_DISK_MB = 512;
+
+export function assertConcurrencyLimit(activeCount: number, limit: number): void {
+  if (activeCount >= limit) {
+    throw new Error(
+      `Too many active tasks (${activeCount}/${limit}). Stop or wait for a running task to finish.`
+    );
+  }
+}
+
+export function assertDiskSpace(availableKb: number, minMb: number = MIN_DISK_MB): void {
+  if (availableKb < minMb * 1024) {
+    throw new Error(
+      `Insufficient disk space: ${Math.floor(availableKb / 1024)} MB available, need at least ${minMb} MB.`
+    );
+  }
+}
+
+async function checkConcurrencyLimit(): Promise<void> {
+  const db = getDb();
+  const config = getConfig();
+  const limit = config.max_concurrent_tasks ?? 10;
+  const row = db
+    .select({ total: count() })
+    .from(schema.tasks)
+    .where(or(eq(schema.tasks.status, "queued"), eq(schema.tasks.status, "running")))
+    .get();
+  assertConcurrencyLimit(row?.total ?? 0, limit);
+}
+
+async function getAvailableKb(path: string): Promise<number> {
+  try {
+    const proc = Bun.spawn(["df", "-Pk", path], { stdout: "pipe", stderr: "pipe" });
+    await proc.exited;
+    const output = await new Response(proc.stdout).text();
+    const lines = output.trim().split("\n");
+    if (lines.length < 2) return Infinity;
+    const parts = lines[1].trim().split(/\s+/);
+    const available = parseInt(parts[3], 10);
+    return isNaN(available) ? Infinity : available;
+  } catch {
+    return Infinity;
+  }
+}
+
+async function checkDiskSpace(projectRoot: string): Promise<void> {
+  if (!projectRoot) return;
+  const availableKb = await getAvailableKb(projectRoot);
+  assertDiskSpace(availableKb);
+}
+
 // Parse comma-separated allow entries into scoped rules + bypass hosts.
-// "host/path" → ScopedAllowRule, "host" → bypass host
+// "host/path" -> ScopedAllowRule, "host" -> bypass host
 function parseAllowedHosts(raw: string | null | undefined): { scopedRules: ScopedAllowRule[]; bypassHosts: string[] } {
   const scopedRules: ScopedAllowRule[] = [];
   const bypassHosts: string[] = [];
@@ -38,7 +89,7 @@ async function fileExists(path: string): Promise<boolean> {
 }
 
 export function shellescape(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`;
+  return "'" + value.replace(/'/g, "'\\'' ".trimEnd()) + "'";
 }
 
 const RESULT_SUFFIX = `
@@ -64,7 +115,7 @@ If you encounter a blocker that prevents you from completing the task — missin
 **On ANY blocker:**
 1. Do NOT retry the same action
 2. Do NOT try to work around it
-3. Write \`[TASK_ABORTED]: <brief reason>\` as your FINAL message
+3. Write [TASK_ABORTED]: <brief reason> as your FINAL message
 4. Stop immediately`;
 
 const REFINE_SUFFIX = "\n\n---\nAfter completing these refinements, read the existing /workspace/RESULT.md and append a new Refinement section at the end describing what was changed in this pass. Keep the existing content intact. Only rewrite earlier sections if the refinement directly invalidates them or if the user explicitly asked for a rewrite.";
@@ -164,8 +215,10 @@ export const taskActionsRouter = router({
       }),
     )
     .mutation(async ({ input }) => {
-      const db = getDb();
       const serverConfig = getServerConfig();
+      await checkConcurrencyLimit();
+      await checkDiskSpace(serverConfig.projectRoot);
+      const db = getDb();
       const taskId = crypto.randomUUID();
       const worktreePrefix = serverConfig.worktreePrefix;
       const projectRoot = serverConfig.projectRoot;
@@ -304,6 +357,10 @@ export const taskActionsRouter = router({
         throw new Error(`Cannot relaunch task in status: ${task.status}`);
       }
 
+      const serverConfig = getServerConfig();
+      await checkConcurrencyLimit();
+      await checkDiskSpace(serverConfig.projectRoot);
+
       // Reset status
       db.update(schema.tasks)
         .set({
@@ -318,8 +375,6 @@ export const taskActionsRouter = router({
         .run();
 
       writeAuditLog("task.relaunch", { task_id: input.taskId });
-
-      const serverConfig = getServerConfig();
 
       // Store prompt for container to fetch (with result + abort instructions appended)
       await fetch(`http://localhost:${serverConfig.port}/api/prompt/${input.taskId}`, {
@@ -397,6 +452,10 @@ export const taskActionsRouter = router({
       }
       if (!task.session_id) throw new Error("No session_id to resume");
 
+      const serverConfig = getServerConfig();
+      await checkConcurrencyLimit();
+      await checkDiskSpace(serverConfig.projectRoot);
+
       db.update(schema.tasks)
         .set({
           status: "running",
@@ -409,8 +468,6 @@ export const taskActionsRouter = router({
         .run();
 
       writeAuditLog("task.continue", { task_id: input.taskId });
-
-      const serverConfig = getServerConfig();
       const continueNetworkPolicy = (task.network_policy ?? "none") as "none" | "strict";
       if (continueNetworkPolicy === "strict") {
         const { scopedRules, bypassHosts: extraBypass } = parseAllowedHosts(task.allowed_hosts);
@@ -479,6 +536,10 @@ export const taskActionsRouter = router({
       }
       if (!task.session_id) throw new Error("No session_id to resume");
 
+      const serverConfig = getServerConfig();
+      await checkConcurrencyLimit();
+      await checkDiskSpace(serverConfig.projectRoot);
+
       db.update(schema.tasks)
         .set({
           status: "running",
@@ -491,8 +552,6 @@ export const taskActionsRouter = router({
         .run();
 
       writeAuditLog("task.refine", { task_id: input.taskId });
-
-      const serverConfig = getServerConfig();
       const refineNetworkPolicy = (task.network_policy ?? "none") as "none" | "strict";
       if (refineNetworkPolicy === "strict") {
         const { scopedRules, bypassHosts: extraBypass } = parseAllowedHosts(task.allowed_hosts);
@@ -692,9 +751,9 @@ podman run --rm -it \\
       chmod +x /home/agent/.claude/hooks/sandbox-guard.sh 2>/dev/null
     fi
     if [ -f /home/agent/.claude.json ]; then
-      jq '.hasCompletedOnboarding = true | .projects[\\\\\"/workspace\\\\\"].hasTrustDialogAccepted = true' /home/agent/.claude.json > /tmp/cj.json 2>/dev/null && mv /tmp/cj.json /home/agent/.claude.json
+      jq '.hasCompletedOnboarding = true | .projects[\\\\"/workspace\\\\"].hasTrustDialogAccepted = true' /home/agent/.claude.json > /tmp/cj.json 2>/dev/null && mv /tmp/cj.json /home/agent/.claude.json
     else
-      echo '{\\\"hasCompletedOnboarding\\\":true,\\\"projects\\\":{\\\"\\/workspace\\\":{\\\"hasTrustDialogAccepted\\\":true}}}' > /home/agent/.claude.json
+      echo '{\\"hasCompletedOnboarding\\":true,\\"projects\\":{\\"\\/workspace\\":{\\"hasTrustDialogAccepted\\":true}}}' > /home/agent/.claude.json
     fi
 
     echo 'gitdir: /repo.git/worktrees/${worktreeName}' > /workspace/.git

--- a/src/db/migrations/0010_add_max_concurrent_tasks.sql
+++ b/src/db/migrations/0010_add_max_concurrent_tasks.sql
@@ -1,0 +1,1 @@
+ALTER TABLE config ADD COLUMN max_concurrent_tasks INTEGER NOT NULL DEFAULT 10;

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1771200008000,
       "tag": "0009_add_auth_token",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1771200009000,
+      "tag": "0010_add_max_concurrent_tasks",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -39,4 +39,5 @@ export const config = sqliteTable("config", {
   anthropic_api_key: text("anthropic_api_key"),
   mistral_api_key: text("mistral_api_key"),
   auth_token: text("auth_token"),
+  max_concurrent_tasks: integer("max_concurrent_tasks").notNull().default(10),
 });


### PR DESCRIPTION
## Summary

Without any concurrency guard, callers of the tRPC API can spawn unlimited Podman containers and fill disk with worktrees and log files. This PR adds two resource guards enforced before every `run`/`relaunch`/`continue`/`refine` mutation:

- **Concurrent task limit** — configurable via `max_concurrent_tasks` (default 10, range 1–100). Counts `queued` + `running` tasks in the DB and rejects new ones when the limit is reached.
- **Disk space check** — requires at least 512 MB free on the project root filesystem before creating a new worktree. Uses `df -Pk` (POSIX-portable). Fails open if `df` is unavailable.

## Changes

| File | Change |
|---|---|
| `src/db/migrations/0010_add_max_concurrent_tasks.sql` | New migration adding `max_concurrent_tasks INTEGER NOT NULL DEFAULT 10` to the config table |
| `src/db/migrations/meta/_journal.json` | Append migration entry idx 9 |
| `src/db/schema.ts` | Add `max_concurrent_tasks` column to config table schema |
| `src/api/config-store.ts` | Add `max_concurrent_tasks: number` to `AppConfig` type and fallback default |
| `src/api/config.ts` | Expose `max_concurrent_tasks` in the `config.set` Zod input (int, min 1, max 100) |
| `src/api/task-actions.ts` | Export `assertConcurrencyLimit` and `assertDiskSpace`; add private `checkConcurrencyLimit` and `checkDiskSpace` helpers; apply guards to `run`/`relaunch`/`continue`/`refine` mutations; extend drizzle import with `or`, `count` |
| `src/api/task-actions.test.ts` | Add unit tests for both assertion functions (ut-3, ut-4) |

## Notes

- `openTerminal` is intentionally excluded — it spawns a container outside the normal task lifecycle and is already gated by user interaction.
- The disk check fails open (`Infinity`) if `df` errors, so unusual environments are not blocked.
- The limit is read fresh from the DB on each mutation, so changes via `config.set` take effect immediately without a restart.

## Test plan

- [x] ut-3: `assertConcurrencyLimit` — does not throw below limit; throws at and above limit with correct message — **14/14 tests pass**
- [x] ut-4: `assertDiskSpace` — does not throw when sufficient; throws when insufficient, message includes available MB — **14/14 tests pass**
- [x] man-1: Start 10 tasks; attempt to start an 11th — verify error contains "Too many active tasks (10/10)"
- [x] man-2: Call `config.set({ max_concurrent_tasks: 3 })`; start 3 tasks; confirm 4th is rejected with "3/3" in the error
