### PR TITLE
feat: generalize sandbox shadow volumes with configurable SHADOW_DIRS

### DIFF
--- a/container/sandbox-run.sh
+++ b/container/sandbox-run.sh
@@ -14,6 +14,7 @@
 # Optional env vars:
 #   SANDBOX_TIMEOUT    -- container timeout in seconds (default: 3600)
 #   LOG_FILE           -- host path for output log (captured via tee)
+#   SHADOW_DIRS        -- space-separated workspace-relative dirs to shadow (default: node_modules)
 
 set -euo pipefail
 
@@ -92,11 +93,15 @@ GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-$GIT_AUTHOR_EMAIL}"
 SESSION_VOLUME="task-session-${TASK_ID}"
 podman volume exists "$SESSION_VOLUME" 2>/dev/null || podman volume create "$SESSION_VOLUME" >/dev/null
 
-# -- node_modules volume -------------------------------------------------------
-# Shadow the worktree's node_modules with a container-specific named volume so
-# the container installs Linux-native binaries there without touching the host copy.
-NODE_MODULES_VOLUME="node-modules-${TASK_ID}"
-podman volume exists "$NODE_MODULES_VOLUME" 2>/dev/null || podman volume create "$NODE_MODULES_VOLUME" >/dev/null
+# -- Shadow volumes (platform-specific build artifacts) ------------------------
+# SHADOW_DIRS is a space-separated list of workspace-relative dirs to shadow with
+# per-task named volumes.  Default: node_modules (backward compatible).
+SHADOW_MOUNTS=""
+for dir in ${SHADOW_DIRS:-node_modules}; do
+  vol="shadow-$(echo "$dir" | tr '/' '-')-${TASK_ID}"
+  podman volume exists "$vol" 2>/dev/null || podman volume create "$vol" >/dev/null
+  SHADOW_MOUNTS="$SHADOW_MOUNTS --mount type=volume,src=$vol,dst=/workspace/$dir"
+done
 
 # -- Git worktree pointer ------------------------------------------------------
 # Write container-internal git pointers from the host before container starts,
@@ -270,7 +275,7 @@ podman run --rm \
   -e GIT_COMMITTER_NAME="${GIT_COMMITTER_NAME:-Sandbox Agent}" \
   -e GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-agent@sandbox}" \
   -v "$WORKTREE:/workspace:rw" \
-  --mount "type=volume,src=${NODE_MODULES_VOLUME},dst=/workspace/node_modules" \
+  $SHADOW_MOUNTS \
   -v "$REPO_MOUNT" \
   --tmpfs /home/agent:rw,nosuid,nodev,size=256m,mode=777 \
   --mount "type=volume,src=${SESSION_VOLUME},dst=/home/agent/.claude" \

--- a/src/runtime/container.test.ts
+++ b/src/runtime/container.test.ts
@@ -5,7 +5,7 @@ import { join } from "path";
 const containerSrc = readFileSync(join(import.meta.dir, "container.ts"), "utf-8");
 
 describe("teardownContainer", () => {
-  it("ut-1: volume rm includes node-modules-${id} but not task-session-${id}", () => {
+  it("ut-1: volume rm includes shadow-node_modules-${id} but not task-session-${id}", () => {
     // Find the podman volume rm line(s) inside teardownContainer
     const teardownMatch = containerSrc.match(
       /export async function teardownContainer[\s\S]*?^}/m
@@ -13,7 +13,20 @@ describe("teardownContainer", () => {
     expect(teardownMatch).not.toBeNull();
     const teardownBody = teardownMatch![0];
 
-    expect(teardownBody).toContain("node-modules-");
+    expect(teardownBody).toContain("shadow-node_modules-");
     expect(teardownBody).not.toContain("task-session-");
+  });
+});
+
+describe("spawnSandbox SHADOW_DIRS", () => {
+  it("ut-2: sets SHADOW_DIRS when shadowDirs provided", () => {
+    // Read container.ts source and verify SHADOW_DIRS is assigned from opts.shadowDirs
+    expect(containerSrc).toContain("SHADOW_DIRS");
+    expect(containerSrc).toContain("opts.shadowDirs");
+  });
+
+  it("ut-3: does not set SHADOW_DIRS when shadowDirs is absent", () => {
+    // Verify the assignment is guarded by a conditional (opts.shadowDirs &&)
+    expect(containerSrc).toMatch(/opts\.shadowDirs.*&&.*SHADOW_DIRS|if.*opts\.shadowDirs/);
   });
 });

--- a/src/runtime/container.ts
+++ b/src/runtime/container.ts
@@ -47,6 +47,7 @@ export interface SpawnSandboxOpts {
   agentImage?: string;        // container image name, e.g. "sandbox-claude" or "sandbox-mistral"
   provider?: string;          // provider id, used for session ID extraction
   extraPodEnv?: string;       // opaque "-e KEY=val -e KEY2=val2" string forwarded verbatim to podman run
+  shadowDirs?: string[];      // forwarded as SHADOW_DIRS env var to sandbox-run.sh
 }
 
 export function spawnSandbox(opts: SpawnSandboxOpts) {
@@ -58,6 +59,7 @@ export function spawnSandbox(opts: SpawnSandboxOpts) {
   if (opts.agentAuthEnvFlags !== undefined) env.AGENT_AUTH_ENV_FLAGS = opts.agentAuthEnvFlags;
   if (opts.agentImage) env.AGENT_IMAGE = opts.agentImage;
   if (opts.extraPodEnv) env.EXTRA_POD_ENV = opts.extraPodEnv;
+  if (opts.shadowDirs && opts.shadowDirs.length > 0) env.SHADOW_DIRS = opts.shadowDirs.join(" ");
 
   return Bun.spawn(
     [
@@ -106,6 +108,6 @@ export async function teardownContainer(
     `podman stop $(podman ps -q --filter label=${label}=${id}) 2>/dev/null || true`,
   );
   await runShell(
-    `podman volume rm node-modules-${id} 2>/dev/null || true`,
+    `podman volume rm shadow-node_modules-${id} 2>/dev/null || true`,
   );
 }

--- a/src/runtime/runner.ts
+++ b/src/runtime/runner.ts
@@ -98,6 +98,7 @@ export async function runTask(config: RunConfig): Promise<RunResult> {
     agentInitScript: containerConfig.initScript,
     agentAuthEnvFlags,
     extraPodEnv: `-e CONTEXT_ID=${taskId}`,
+    shadowDirs: config.shadowDirs,
   });
 
   const exitCode = await proc.exited;

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export interface RunConfig {
   resumePrompt?: string; // custom prompt for session resume (refine)
   networkPolicy?: "none" | "strict" | "custom"; // default "none"
   promptUrl?: string; // URL for container to fetch prompt from
+  shadowDirs?: string[]; // dirs to shadow with per-task volumes (default: ["node_modules"])
 }
 
 // What runTask() returns


### PR DESCRIPTION
## Summary

- Replace the hardcoded `node-modules-${TASK_ID}` named volume in `container/sandbox-run.sh` with a generic loop driven by `SHADOW_DIRS` (space-separated list of workspace-relative directories). Default is `node_modules`, keeping full backward compatibility.
- Volumes are now named `shadow-<dir>-<task_id>` (e.g. `shadow-node_modules-abc123`). Slashes in dir names are converted to dashes via `tr '/' '-'`.
- `teardownContainer` updated to remove `shadow-node_modules-<id>` (the new default name).
- `shadowDirs?: string[]` added to `RunConfig` and `SpawnSandboxOpts`; forwarded as the `SHADOW_DIRS` env var into the sandbox script.

## Changes

- **`container/sandbox-run.sh`** — Replace fixed `node-modules` block with `SHADOW_DIRS` loop; use `$SHADOW_MOUNTS` in `podman run`; document new env var in header comment.
- **`src/types.ts`** — Add `shadowDirs?: string[]` to `RunConfig`.
- **`src/runtime/container.ts`** — Add `shadowDirs` to `SpawnSandboxOpts`; set `SHADOW_DIRS` env var in `spawnSandbox()`; update `teardownContainer` to use `shadow-node_modules-` prefix.
- **`src/runtime/runner.ts`** — Forward `config.shadowDirs` into `spawnSandbox()`.
- **`src/runtime/container.test.ts`** — Update ut-1 for new volume name; add ut-2 and ut-3 for `SHADOW_DIRS` wiring.

## Notes

Volumes from prior runs under the old `node-modules-<id>` name will be orphaned; run `podman volume prune` to clean them up. Full generalization of `teardownContainer` for arbitrary `shadowDirs` lists is tracked separately.