### PR TITLE
feat: add mise universal toolchain manager to agent container images

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -80,6 +80,11 @@ RUN chmod +x /opt/proxy/oci-network-hook.sh
 
 USER agent
 
+# Install mise universal toolchain manager
+RUN curl https://mise.run | sh
+ENV PATH="/home/agent/.local/bin:$PATH"
+RUN mise --version
+
 # Lock down git against local config code execution attacks
 # GIT_CONFIG_COUNT/KEY/VALUE env vars override local .git/config
 # These take highest precedence (after -c flags) and cannot be overridden

--- a/container/Containerfile.mistral
+++ b/container/Containerfile.mistral
@@ -56,6 +56,11 @@ RUN chmod +x /opt/proxy/oci-network-hook.sh
 
 USER agent
 
+# Install mise universal toolchain manager
+RUN curl https://mise.run | sh
+ENV PATH="/home/agent/.local/bin:$PATH"
+RUN mise --version
+
 # Lock down git via env vars (same as Claude image)
 ENV GIT_CONFIG_COUNT=17 \
     GIT_CONFIG_KEY_0=core.fsmonitor \

--- a/src/container/sandbox-run.test.ts
+++ b/src/container/sandbox-run.test.ts
@@ -16,3 +16,23 @@ describe("sandbox-run.sh", () => {
     expect(curlLine).toContain("--connect-timeout 5");
   });
 });
+
+describe("Containerfiles — mise", () => {
+  const containerfilePath = join(import.meta.dir, "../../container/Containerfile");
+  const containerfileContent = readFileSync(containerfilePath, "utf-8");
+
+  const containerfileMistralPath = join(import.meta.dir, "../../container/Containerfile.mistral");
+  const containerfileMistralContent = readFileSync(containerfileMistralPath, "utf-8");
+
+  it("ut-1: container/Containerfile contains all three mise install lines", () => {
+    expect(containerfileContent).toContain("curl https://mise.run | sh");
+    expect(containerfileContent).toContain('ENV PATH="/home/agent/.local/bin');
+    expect(containerfileContent).toContain("mise --version");
+  });
+
+  it("ut-2: container/Containerfile.mistral contains all three mise install lines", () => {
+    expect(containerfileMistralContent).toContain("curl https://mise.run | sh");
+    expect(containerfileMistralContent).toContain('ENV PATH="/home/agent/.local/bin');
+    expect(containerfileMistralContent).toContain("mise --version");
+  });
+});


### PR DESCRIPTION
## Summary

- Install the `mise` universal toolchain manager binary into both agent Containerfiles (`container/Containerfile` and `container/Containerfile.mistral`) as the `agent` user
- Add `/home/agent/.local/bin` to `PATH` via `ENV` so `mise` and any tools it installs are available in subsequent build layers and at runtime
- Verify the install with `RUN mise --version` to catch any install failures at build time
- Add unit tests in `src/container/sandbox-run.test.ts` asserting both Containerfiles contain the expected install lines

## Notes

- `curl` is already present in both images (`apk add ... curl ...`), so no additional packages needed
- The `~/.local/share/mise/installs/` data directory is intentionally **not** baked into the image — it will be a shared named volume at runtime (tracked in #30)
- `container/Containerfile.proxy` is the network proxy image and does **not** need mise
- Image size increase is approximately 5 MB for the mise binary
- Depends on: downstream #30 (shared mise-installs volume), #31 (mise init in sandbox-run.sh)

## Test plan

- [x] Unit test ut-1: `container/Containerfile` contains `curl https://mise.run | sh`, `ENV PATH="/home/agent/.local/bin`, and `mise --version`
- [x] Unit test ut-2: `container/Containerfile.mistral` contains the same three strings
- [x] Manual: build `sandbox-claude` image and verify `mise --version` exits 0