### PR TITLE
feat: add language detection and shadow_dirs presets

### DIFF
--- a/src/runtime/detect-language.test.ts
+++ b/src/runtime/detect-language.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "path";
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { detectLanguage, getRegistryHostsForLanguage } from "./detect-language";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "detect-language-test-"));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("detectLanguage", () => {
+  it("ut-1: returns go when go.mod is present", async () => {
+    await writeFile(join(tmpDir, "go.mod"), "");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "go", shadowDirs: [] });
+  });
+
+  it("ut-2: returns rust when Cargo.toml is present", async () => {
+    await writeFile(join(tmpDir, "Cargo.toml"), "");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "rust", shadowDirs: ["target"] });
+  });
+
+  it("ut-2: returns elixir when mix.exs is present", async () => {
+    await writeFile(join(tmpDir, "mix.exs"), "");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "elixir", shadowDirs: ["_build", "deps"] });
+  });
+
+  it("ut-2: returns swift when Package.swift is present", async () => {
+    await writeFile(join(tmpDir, "Package.swift"), "");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "swift", shadowDirs: [".build"] });
+  });
+
+  it("ut-3: returns dotnet when a .csproj file is present", async () => {
+    await writeFile(join(tmpDir, "App.csproj"), "");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "dotnet", shadowDirs: ["bin", "obj"] });
+  });
+
+  it("ut-3: returns dotnet when a .sln file is present", async () => {
+    await writeFile(join(tmpDir, "Solution.sln"), "");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "dotnet", shadowDirs: ["bin", "obj"] });
+  });
+
+  it("ut-2: returns java-maven when pom.xml is present", async () => {
+    await writeFile(join(tmpDir, "pom.xml"), "");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "java-maven", shadowDirs: ["target"] });
+  });
+
+  it("ut-2: returns java-gradle when build.gradle is present", async () => {
+    await writeFile(join(tmpDir, "build.gradle"), "");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "java-gradle", shadowDirs: ["build", ".gradle"] });
+  });
+
+  it("ut-4: returns java-gradle when build.gradle.kts is present", async () => {
+    await writeFile(join(tmpDir, "build.gradle.kts"), "");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "java-gradle", shadowDirs: ["build", ".gradle"] });
+  });
+
+  it("ut-2: returns ruby when Gemfile is present", async () => {
+    await writeFile(join(tmpDir, "Gemfile"), "");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "ruby", shadowDirs: ["vendor/bundle"] });
+  });
+
+  it("ut-2: returns php when composer.json is present", async () => {
+    await writeFile(join(tmpDir, "composer.json"), "");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "php", shadowDirs: ["vendor"] });
+  });
+
+  it("ut-5: returns python when pyproject.toml is present", async () => {
+    await writeFile(join(tmpDir, "pyproject.toml"), "");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "python", shadowDirs: [".venv"] });
+  });
+
+  it("ut-5: returns python when requirements.txt is present", async () => {
+    await writeFile(join(tmpDir, "requirements.txt"), "");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "python", shadowDirs: [".venv"] });
+  });
+
+  it("ut-5: returns python when Pipfile is present", async () => {
+    await writeFile(join(tmpDir, "Pipfile"), "");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "python", shadowDirs: [".venv"] });
+  });
+
+  it("ut-2: returns c-cpp when CMakeLists.txt is present", async () => {
+    await writeFile(join(tmpDir, "CMakeLists.txt"), "");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "c-cpp", shadowDirs: ["build"] });
+  });
+
+  it("ut-2: returns node when package.json is present", async () => {
+    await writeFile(join(tmpDir, "package.json"), "{}");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "node", shadowDirs: ["node_modules"] });
+  });
+
+  it("ut-6: returns unknown with node_modules when no markers present", async () => {
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "unknown", shadowDirs: ["node_modules"] });
+  });
+
+  it("go takes priority over node (package.json present alongside go.mod)", async () => {
+    await writeFile(join(tmpDir, "go.mod"), "");
+    await writeFile(join(tmpDir, "package.json"), "{}");
+    expect(await detectLanguage(tmpDir)).toEqual({ language: "go", shadowDirs: [] });
+  });
+});
+
+describe("getRegistryHostsForLanguage", () => {
+  it("ut-7: returns correct hosts for node", () => {
+    expect(getRegistryHostsForLanguage("node")).toEqual(["registry.npmjs.org", "registry.yarnpkg.com"]);
+  });
+
+  it("ut-7: returns correct hosts for python", () => {
+    expect(getRegistryHostsForLanguage("python")).toEqual(["pypi.org", "files.pythonhosted.org"]);
+  });
+
+  it("ut-7: returns correct hosts for go", () => {
+    expect(getRegistryHostsForLanguage("go")).toEqual(["proxy.golang.org", "sum.golang.org", "storage.googleapis.com"]);
+  });
+
+  it("ut-7: returns correct hosts for rust", () => {
+    expect(getRegistryHostsForLanguage("rust")).toEqual(["static.crates.io", "crates.io"]);
+  });
+
+  it("ut-7: returns correct hosts for ruby", () => {
+    expect(getRegistryHostsForLanguage("ruby")).toEqual(["rubygems.org", "index.rubygems.org"]);
+  });
+
+  it("ut-7: returns correct hosts for php", () => {
+    expect(getRegistryHostsForLanguage("php")).toEqual(["repo.packagist.org", "packagist.org"]);
+  });
+
+  it("ut-7: returns correct hosts for java-maven", () => {
+    expect(getRegistryHostsForLanguage("java-maven")).toEqual(["repo1.maven.org", "plugins.gradle.org"]);
+  });
+
+  it("ut-7: returns correct hosts for java-gradle", () => {
+    expect(getRegistryHostsForLanguage("java-gradle")).toEqual(["repo1.maven.org", "plugins.gradle.org"]);
+  });
+
+  it("ut-7: returns correct hosts for dotnet", () => {
+    expect(getRegistryHostsForLanguage("dotnet")).toEqual(["api.nuget.org", "globalcdn.nuget.org"]);
+  });
+
+  it("ut-7: returns correct hosts for elixir", () => {
+    expect(getRegistryHostsForLanguage("elixir")).toEqual(["hex.pm", "repo.hex.pm"]);
+  });
+
+  it("ut-8: returns [] for swift", () => {
+    expect(getRegistryHostsForLanguage("swift")).toEqual([]);
+  });
+
+  it("ut-8: returns [] for c-cpp", () => {
+    expect(getRegistryHostsForLanguage("c-cpp")).toEqual([]);
+  });
+
+  it("ut-8: returns [] for unknown", () => {
+    expect(getRegistryHostsForLanguage("unknown")).toEqual([]);
+  });
+});

--- a/src/runtime/detect-language.ts
+++ b/src/runtime/detect-language.ts
@@ -1,0 +1,139 @@
+import { stat, readdir } from "fs/promises";
+import { join } from "path";
+
+export type DetectedLanguage =
+  | "go"
+  | "rust"
+  | "elixir"
+  | "swift"
+  | "dotnet"
+  | "java-maven"
+  | "java-gradle"
+  | "ruby"
+  | "php"
+  | "python"
+  | "c-cpp"
+  | "node"
+  | "unknown";
+
+export interface LanguageDetectionResult {
+  language: DetectedLanguage;
+  shadowDirs: string[];
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface DetectionRule {
+  check(root: string): Promise<boolean>;
+  language: DetectedLanguage;
+  shadowDirs: string[];
+}
+
+const RULES: DetectionRule[] = [
+  {
+    check: (root) => fileExists(join(root, "go.mod")),
+    language: "go",
+    shadowDirs: [],
+  },
+  {
+    check: (root) => fileExists(join(root, "Cargo.toml")),
+    language: "rust",
+    shadowDirs: ["target"],
+  },
+  {
+    check: (root) => fileExists(join(root, "mix.exs")),
+    language: "elixir",
+    shadowDirs: ["_build", "deps"],
+  },
+  {
+    check: (root) => fileExists(join(root, "Package.swift")),
+    language: "swift",
+    shadowDirs: [".build"],
+  },
+  {
+    check: async (root) => {
+      let entries: string[];
+      try {
+        entries = await readdir(root);
+      } catch {
+        return false;
+      }
+      return entries.some((e) => e.endsWith(".csproj") || e.endsWith(".sln"));
+    },
+    language: "dotnet",
+    shadowDirs: ["bin", "obj"],
+  },
+  {
+    check: (root) => fileExists(join(root, "pom.xml")),
+    language: "java-maven",
+    shadowDirs: ["target"],
+  },
+  {
+    check: async (root) =>
+      (await fileExists(join(root, "build.gradle"))) ||
+      (await fileExists(join(root, "build.gradle.kts"))),
+    language: "java-gradle",
+    shadowDirs: ["build", ".gradle"],
+  },
+  {
+    check: (root) => fileExists(join(root, "Gemfile")),
+    language: "ruby",
+    shadowDirs: ["vendor/bundle"],
+  },
+  {
+    check: (root) => fileExists(join(root, "composer.json")),
+    language: "php",
+    shadowDirs: ["vendor"],
+  },
+  {
+    check: async (root) =>
+      (await fileExists(join(root, "pyproject.toml"))) ||
+      (await fileExists(join(root, "requirements.txt"))) ||
+      (await fileExists(join(root, "Pipfile"))),
+    language: "python",
+    shadowDirs: [".venv"],
+  },
+  {
+    check: (root) => fileExists(join(root, "CMakeLists.txt")),
+    language: "c-cpp",
+    shadowDirs: ["build"],
+  },
+  {
+    check: (root) => fileExists(join(root, "package.json")),
+    language: "node",
+    shadowDirs: ["node_modules"],
+  },
+];
+
+export async function detectLanguage(worktreeRoot: string): Promise<LanguageDetectionResult> {
+  for (const rule of RULES) {
+    if (await rule.check(worktreeRoot)) {
+      return { language: rule.language, shadowDirs: rule.shadowDirs };
+    }
+  }
+  return { language: "unknown", shadowDirs: ["node_modules"] };
+}
+
+const REGISTRY_HOSTS: Partial<Record<DetectedLanguage, string[]>> = {
+  node: ["registry.npmjs.org", "registry.yarnpkg.com"],
+  python: ["pypi.org", "files.pythonhosted.org"],
+  go: ["proxy.golang.org", "sum.golang.org", "storage.googleapis.com"],
+  rust: ["static.crates.io", "crates.io"],
+  ruby: ["rubygems.org", "index.rubygems.org"],
+  php: ["repo.packagist.org", "packagist.org"],
+  "java-maven": ["repo1.maven.org", "plugins.gradle.org"],
+  "java-gradle": ["repo1.maven.org", "plugins.gradle.org"],
+  dotnet: ["api.nuget.org", "globalcdn.nuget.org"],
+  elixir: ["hex.pm", "repo.hex.pm"],
+};
+
+export function getRegistryHostsForLanguage(lang: DetectedLanguage): string[] {
+  return REGISTRY_HOSTS[lang] ?? [];
+}

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -6,3 +6,5 @@ export type { SpawnSandboxOpts } from "./container";
 export { parseOutput, buildClaudeCommand } from "./output";
 export { ensureProxy, stopProxy } from "./proxy";
 export type { ScopedAllowRule } from "./proxy";
+export { detectLanguage, getRegistryHostsForLanguage } from "./detect-language";
+export type { DetectedLanguage, LanguageDetectionResult } from "./detect-language";


### PR DESCRIPTION
## Summary

Adds `src/runtime/detect-language.ts` — a new host-side module that inspects a project's worktree root for well-known marker files and returns the detected language along with its default `shadowDirs`.

This is a prerequisite for:
- #33 — wiring `detectLanguage` into the runner and schema
- #34 — using `getRegistryHostsForLanguage` to build per-language network proxy allowlists
- #35 — exposing the detected language in the dashboard UI

## Changes

- **`src/runtime/detect-language.ts`** (new) — `detectLanguage(worktreeRoot)` walks a priority-ordered rule table checking for marker files (`go.mod`, `Cargo.toml`, `mix.exs`, `Package.swift`, `*.csproj`/`*.sln`, `pom.xml`, `build.gradle[.kts]`, `Gemfile`, `composer.json`, `pyproject.toml`/`requirements.txt`/`Pipfile`, `CMakeLists.txt`, `package.json`). Returns `{ language, shadowDirs }`. Falls back to `{ language: "unknown", shadowDirs: ["node_modules"] }` matching the existing runtime default. `getRegistryHostsForLanguage(lang)` is a pure map of language → package registry hostnames for 10 languages.

- **`src/runtime/detect-language.test.ts`** (new) — 31 unit tests covering all 12 languages, both dotnet glob patterns, `build.gradle.kts`, all three Python markers, the unknown fallback, rule priority, and all `getRegistryHostsForLanguage` mappings.

- **`src/runtime/index.ts`** — re-exports `detectLanguage`, `getRegistryHostsForLanguage`, `DetectedLanguage`, and `LanguageDetectionResult`.

## Test plan

- [x] `bun test src/runtime/detect-language.test.ts` — 31/31 pass
- [x] `bun test src/runtime/` — 36/36 pass (no regressions in existing suites)
- [x] `bun run typecheck` — no new type errors introduced (pre-existing errors in `client/` are unrelated)