### PR TITLE
feat: run mise install in sandbox init to provision project runtimes

### DIFF
--- a/container/sandbox-run.sh
+++ b/container/sandbox-run.sh
@@ -305,6 +305,12 @@ podman run --rm \
       fi
     fi
 
+    # Install project toolchain via mise if declared
+    if [ -f /workspace/.mise.toml ] || [ -f /workspace/.tool-versions ]; then
+      _progress 'Installing runtimes via mise...'
+      mise install --cd /workspace --yes 2>/dev/null || true
+    fi
+
     AGENT_BIN=\"\${AGENT_BINARY:-claude}\"
 
     # Prompt handling: -p means args are self-contained; --resume without -p fetches prompt from PROMPT_URL


### PR DESCRIPTION
## Summary

When a project declares runtimes via `.mise.toml` or `.tool-versions`, those runtimes are not automatically installed before the agent starts. This change adds a `mise install` step in the container init block of `container/sandbox-run.sh`, executed after the onboarding bypass and before the agent binary is launched.

- Checks for `.mise.toml` or `.tool-versions` in the workspace root
- Emits a progress event (`Installing runtimes via mise...`) visible in task logs
- Runs `mise install --cd /workspace --yes` with stderr suppressed to avoid polluting the structured JSON log stream
- Uses `|| true` so a malformed config never aborts the agent session
- Runtimes already cached in the `mise-installs` shared volume are instantaneous; new runtimes are downloaded at startup

## Changes

- **`container/sandbox-run.sh`** — add 5-line mise install block inside the `podman run -c` init script, between the onboarding-bypass `fi` and `AGENT_BIN=` assignment

## Prerequisites already in place

- `mise` is installed in the image at `/home/agent/.local/bin/mise` (PR #28)
- `MISE_DATA_DIR=/home/agent/.local/share/mise` is passed via `-e` into the container
- `mise-installs` named volume is mounted at `/home/agent/.local/share/mise/installs` (PR #31 ML4)

## Test plan

- [x] `bash -n container/sandbox-run.sh` exits 0 (no syntax errors)
- [x] Run a task against a repo with `.mise.toml` declaring a Node.js version — confirm `Installing runtimes via mise...` appears in task log and `node --version` matches
- [x] Run a task against a repo with no `.mise.toml` or `.tool-versions` — confirm no mise message, container starts normally