### PR TITLE
feat: add installDepsInShadow and export getShadowDirsForLanguages

### DIFF
--- a/container/sandbox-run.sh
+++ b/container/sandbox-run.sh
@@ -306,7 +306,7 @@ podman run --rm \
         cp /etc/claude-defaults/settings.json /home/agent/.claude/settings.json
       fi
       if [ -f /home/agent/.claude.json ]; then
-        jq '.hasCompletedOnboarding = true | .projects[\\\"/workspace\\\"].hasTrustDialogAccepted = true' /home/agent/.claude.json > /tmp/cj.json 2>/dev/null && mv /tmp/cj.json /home/agent/.claude.json
+        jq '.hasCompletedOnboarding = true | .projects[\\\"/workspace\\\"].hasTrustDialogAccepted = true' /home/agent/.claude.json > /tmp/cj.json 2>/dev/null && cp /tmp/cj.json /home/agent/.claude.json && rm -f /tmp/cj.json
       else
         echo '{\"hasCompletedOnboarding\":true,\"projects\":{\"/workspace\":{\"hasTrustDialogAccepted\":true}}}' > /home/agent/.claude.json
       fi

--- a/src/runtime/container.ts
+++ b/src/runtime/container.ts
@@ -162,6 +162,60 @@ export async function installRuntimes(
   return { ok, error: ok ? undefined : errLines.join("\n").trim() };
 }
 
+// Run installCmd inside a short-lived container with the shadow volume mounted.
+// This ensures packages land in the shadow volume, not the host worktree.
+export async function installDepsInShadow(opts: {
+  worktree: string;
+  installCmd: string;
+  shadowVolume: string;
+  shadowDir: string;         // workspace-relative dir, e.g. "node_modules"
+  image?: string;
+  miseVolume?: string;
+  binPathsFile?: string;     // path inside miseVolume to .bin-paths
+}): Promise<{ ok: boolean; error?: string }> {
+  const image = opts.image ?? "sandbox-claude";
+  const binPathsFile = opts.binPathsFile ?? "/home/agent/.local/share/mise/installs/.bin-paths";
+
+  await runShell(`podman volume exists ${opts.shadowVolume} 2>/dev/null || podman volume create ${opts.shadowVolume}`);
+
+  const activateMise = opts.miseVolume
+    ? `if [ -s ${binPathsFile} ]; then export PATH="$(cat ${binPathsFile}):$PATH"; fi`
+    : "";
+
+  const script = [
+    activateMise,
+    `cd /workspace && ${opts.installCmd}`,
+  ].filter(Boolean).join("\n");
+
+  const args = [
+    "podman", "run", "--rm",
+    "--userns=keep-id",
+    "--network", "slirp4netns",
+    "--cap-drop", "ALL",
+    "--security-opt", "no-new-privileges",
+    "-v", `${opts.worktree}:/workspace:rw`,
+    "--mount", `type=volume,src=${opts.shadowVolume},dst=/workspace/${opts.shadowDir}`,
+  ];
+
+  if (opts.miseVolume) {
+    args.push("--mount", `type=volume,src=${opts.miseVolume},dst=/home/agent/.local/share/mise/installs`);
+  }
+
+  args.push(image, "-c", script);
+
+  const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
+
+  const errLines: string[] = [];
+  await Promise.all([
+    streamLines(proc.stdout, () => {}),
+    streamLines(proc.stderr, (line) => errLines.push(line)),
+    proc.exited,
+  ]);
+
+  const ok = proc.exitCode === 0;
+  return { ok, error: ok ? undefined : errLines.join("\n").trim() };
+}
+
 export interface SpawnSandboxOpts {
   worktree: string;
   gitDir: string;

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,10 +1,10 @@
 export { runTask } from "./runner";
 export { getAuthEnv } from "./auth";
 export { createWorktree, removeWorktree, prepareWorktree } from "./worktree";
-export { spawnSandbox, stopContainer, teardownContainer, SECCOMP_PROFILE, rebuildSandboxImage, installRuntimes } from "./container";
+export { spawnSandbox, stopContainer, teardownContainer, SECCOMP_PROFILE, rebuildSandboxImage, installRuntimes, installDepsInShadow } from "./container";
 export type { SpawnSandboxOpts } from "./container";
 export { parseOutput, buildClaudeCommand } from "./output";
 export { ensureProxy, stopProxy } from "./proxy";
 export type { ScopedAllowRule } from "./proxy";
-export { detectLanguage, getRegistryHostsForLanguage, getMiseToolsForLanguages } from "./detect-language";
+export { detectLanguage, getRegistryHostsForLanguage, getMiseToolsForLanguages, getShadowDirsForLanguages } from "./detect-language";
 export type { DetectedLanguage, LanguageDetectionResult, MiseInstallSpec } from "./detect-language";


### PR DESCRIPTION
## Summary
- Add `installDepsInShadow` to run package installation inside a short-lived container with shadow volumes mounted, ensuring deps land in the volume rather than the host worktree
- Export `getShadowDirsForLanguages` from the runtime index
- Fix `sandbox-run.sh` to use `cp`+`rm` instead of `mv` to avoid cross-device issues on `/tmp` writes