### PR TITLE
fix: embed container files in compiled binary

### DIFF
--- a/src/api/task-actions.ts
+++ b/src/api/task-actions.ts
@@ -5,7 +5,7 @@ import { eq, or, count } from "drizzle-orm";
 import { writeFile, readFile, stat, unlink, mkdir } from "fs/promises";
 import { join } from "path";
 import { runTask } from "../runtime/runner";
-import { stopContainer, teardownContainer, SECCOMP_PROFILE } from "../runtime/container";
+import { stopContainer, teardownContainer, getSeccompProfile } from "../runtime/container";
 import { removeWorktree } from "../runtime/worktree";
 import { getProvider } from "../providers";
 import { ensureProxy } from "../runtime/proxy";
@@ -746,6 +746,7 @@ export const taskActionsRouter = router({
 
       const launcherPath = join(launchersDir, `claude-refine-${input.taskId}.sh`);
       const tokenEnvPath = join(launchersDir, `token-${input.taskId}.env`);
+      const seccompProfile = await getSeccompProfile();
 
       await writeFile(tokenEnvPath, `export CLAUDE_CODE_OAUTH_TOKEN=${shellescape(oauthToken)}\n`, { mode: 0o600 });
 
@@ -767,7 +768,7 @@ podman run --rm -it \\
   --add-host host.containers.internal:host-gateway \\
   --cap-drop ALL \\
   --security-opt no-new-privileges \\
-  --security-opt seccomp=${shellescape(SECCOMP_PROFILE)} \\
+  --security-opt seccomp=${shellescape(seccompProfile)} \\
   --read-only \\
   --tmpfs /tmp:rw,nosuid,size=256m \\
   --tmpfs /dev/shm:rw,nosuid,nodev,noexec,size=64m \\

--- a/src/runtime/container.ts
+++ b/src/runtime/container.ts
@@ -1,4 +1,5 @@
 import { readFile, stat } from "fs/promises";
+import { existsSync, mkdirSync } from "fs";
 import { resolve } from "path";
 import { getProvider } from "../providers";
 
@@ -26,10 +27,58 @@ async function runShell(
   return { ok: exitCode === 0, stdout: stdout.trim(), stderr: stderr.trim() };
 }
 
-// Resolve paths relative to this package's container/ dir
-const SANDBOX_SCRIPT = resolve(import.meta.dir, "..", "..", "container", "sandbox-run.sh");
-export const SECCOMP_PROFILE = resolve(import.meta.dir, "..", "..", "container", "seccomp.json");
-const CONTAINER_DIR = resolve(import.meta.dir, "..", "..", "container");
+// Bun embeds these at compile time when referenced via new URL(..., import.meta.url)
+const _embedded: Record<string, ReturnType<typeof Bun.file>> = {
+  "sandbox-run.sh": Bun.file(new URL("../../container/sandbox-run.sh", import.meta.url)),
+  "seccomp.json": Bun.file(new URL("../../container/seccomp.json", import.meta.url)),
+  "Containerfile": Bun.file(new URL("../../container/Containerfile", import.meta.url)),
+  "Containerfile.mistral": Bun.file(new URL("../../container/Containerfile.mistral", import.meta.url)),
+  "Containerfile.proxy": Bun.file(new URL("../../container/Containerfile.proxy", import.meta.url)),
+  "generate-ca.sh": Bun.file(new URL("../../container/generate-ca.sh", import.meta.url)),
+  "git-push-guard.sh": Bun.file(new URL("../../container/git-push-guard.sh", import.meta.url)),
+  "git-safe-wrapper.sh": Bun.file(new URL("../../container/git-safe-wrapper.sh", import.meta.url)),
+  "container-sandbox-guard.sh": Bun.file(new URL("../../container/container-sandbox-guard.sh", import.meta.url)),
+  "claude-settings.json": Bun.file(new URL("../../container/claude-settings.json", import.meta.url)),
+  "network-proxy.ts": Bun.file(new URL("../../container/network-proxy.ts", import.meta.url)),
+  "vibe-config.toml": Bun.file(new URL("../../container/vibe-config.toml", import.meta.url)),
+};
+
+const _builtInDir = resolve(import.meta.dir, "..", "..", "container");
+const _cacheDir = resolve(process.env.HOME ?? "~", ".cache", "ysa-agent", "container");
+
+// In non-compiled installs the built-in dir exists — use it directly.
+// In compiled binaries import.meta.dir is baked from the build machine, so fall back to cache.
+const _containerDir = existsSync(resolve(_builtInDir, "sandbox-run.sh")) ? _builtInDir : _cacheDir;
+
+const SANDBOX_SCRIPT = resolve(_containerDir, "sandbox-run.sh");
+const CONTAINER_DIR = _containerDir;
+
+let _extracting: Promise<void> | null = null;
+
+async function ensureContainerFiles(): Promise<void> {
+  if (_containerDir === _builtInDir) return;
+  if (existsSync(resolve(_cacheDir, "sandbox-run.sh"))) return;
+  if (_extracting) return _extracting;
+  _extracting = (async () => {
+    mkdirSync(_cacheDir, { recursive: true });
+    for (const [name, file] of Object.entries(_embedded)) {
+      await Bun.write(resolve(_cacheDir, name), await file.arrayBuffer());
+    }
+    await Bun.spawn(["chmod", "+x",
+      resolve(_cacheDir, "sandbox-run.sh"),
+      resolve(_cacheDir, "generate-ca.sh"),
+      resolve(_cacheDir, "git-push-guard.sh"),
+      resolve(_cacheDir, "git-safe-wrapper.sh"),
+      resolve(_cacheDir, "container-sandbox-guard.sh"),
+    ]).exited;
+  })();
+  return _extracting;
+}
+
+export async function getSeccompProfile(): Promise<string> {
+  await ensureContainerFiles();
+  return resolve(_containerDir, "seccomp.json");
+}
 
 // Rebuild the sandbox-claude image with optional apk packages (e.g. ["php", "ruby"]).
 // Generates a fresh CA cert, builds with --build-arg EXTRA_PACKAGES, then cleans up.
@@ -58,6 +107,7 @@ export async function rebuildSandboxImage(
   onLog?: (line: string) => void,
   caDir?: string,
 ): Promise<{ ok: boolean; error?: string }> {
+  await ensureContainerFiles();
   // Resolve CA cert: reuse persisted cert from caDir if present, otherwise generate fresh
   if (caDir && await Bun.file(resolve(caDir, "ca.pem")).exists()) {
     await runShell(`cp "${caDir}/ca.pem" "${CONTAINER_DIR}/ca.pem" && cp "${caDir}/ca-key.pem" "${CONTAINER_DIR}/ca-key.pem"`);
@@ -237,7 +287,8 @@ export interface SpawnSandboxOpts {
   miseVolume?: string;        // name of the pre-populated mise-installs volume to mount
 }
 
-export function spawnSandbox(opts: SpawnSandboxOpts) {
+export async function spawnSandbox(opts: SpawnSandboxOpts) {
+  await ensureContainerFiles();
   const env: Record<string, string> = { ...process.env as Record<string, string>, ...opts.env };
   if (opts.logPath) env.LOG_FILE = opts.logPath;
   if (opts.networkPolicy) env.NETWORK_POLICY = opts.networkPolicy;

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,7 +1,7 @@
 export { runTask } from "./runner";
 export { getAuthEnv } from "./auth";
 export { createWorktree, removeWorktree, prepareWorktree } from "./worktree";
-export { spawnSandbox, stopContainer, teardownContainer, SECCOMP_PROFILE, rebuildSandboxImage, installRuntimes, installDepsInShadow } from "./container";
+export { spawnSandbox, stopContainer, teardownContainer, getSeccompProfile, rebuildSandboxImage, installRuntimes, installDepsInShadow } from "./container";
 export type { SpawnSandboxOpts } from "./container";
 export { parseOutput, buildClaudeCommand } from "./output";
 export { ensureProxy, stopProxy } from "./proxy";

--- a/src/runtime/proxy.ts
+++ b/src/runtime/proxy.ts
@@ -1,9 +1,8 @@
-import { resolve } from "path";
+import { getSeccompProfile } from "./container";
 
 const PROXY_CONTAINER_NAME = "ysa-proxy";
 const PROXY_PORT = 3128;
 const IMAGE = "sandbox-proxy";
-const SECCOMP_PROFILE = resolve(import.meta.dir, "..", "..", "container", "seccomp.json");
 
 export interface ScopedAllowRule {
   host: string;       // e.g. "api.example.com"
@@ -81,6 +80,7 @@ export async function startProxy(scopedRules?: ScopedAllowRule[], bypassHosts?: 
     policyEnv += ` -e PROXY_POLICY=${JSON.stringify(JSON.stringify(policy))}`;
   }
 
+  const seccompProfile = await getSeccompProfile();
   const { ok, stderr } = await runShell(
     `podman run -d \
       --name ${PROXY_CONTAINER_NAME} \
@@ -88,7 +88,7 @@ export async function startProxy(scopedRules?: ScopedAllowRule[], bypassHosts?: 
       --network slirp4netns \
       --cap-drop ALL \
       --security-opt no-new-privileges \
-      --security-opt seccomp="${SECCOMP_PROFILE}" \
+      --security-opt seccomp="${seccompProfile}" \
       --read-only \
       --tmpfs /tmp:rw,noexec,nosuid,size=64m \
       --memory 512m \

--- a/src/runtime/runner.ts
+++ b/src/runtime/runner.ts
@@ -83,7 +83,7 @@ export async function runTask(config: RunConfig): Promise<RunResult> {
   if (config.promptUrl) env.PROMPT_URL = config.promptUrl;
   env.PROMPT_TOKEN = getOrCreateAuthToken();
 
-  const proc = spawnSandbox({
+  const proc = await spawnSandbox({
     worktree,
     gitDir,
     branch,


### PR DESCRIPTION
## Summary

- `import.meta.dir` in Bun compiled binaries is baked from the build machine's absolute path at compile time, making container files unreachable when the binary runs on a different machine
- Use `Bun.file(new URL(..., import.meta.url))` so container files are embedded into the binary at compile time and extracted to `~/.cache/ysa-agent/container/` on first use
- Non-compiled installs (npm, local dev) are unaffected — built-in path is detected at startup and used directly, extraction is a no-op

## Test plan

- [x] Compiled binary: verify container files are extracted to `~/.cache/ysa-agent/container/` on first run
- [x] Non-compiled: verify existing behavior unchanged, no files written to cache
- [x] `spawnSandbox` runs successfully with extracted `sandbox-run.sh`
- [x] `rebuildSandboxImage` runs successfully with extracted `Containerfile` and scripts