### PR TITLE
fix: restore worktree pointer on exit trap and clear error on success result

### DIFF
--- a/container/sandbox-run.sh
+++ b/container/sandbox-run.sh
@@ -169,6 +169,11 @@ cleanup_monitor() {
     wait "$MONITOR_PID" 2>/dev/null || true
   fi
   rm -f "${SETTINGS_TMP:-}"
+  # Always restore host-side git worktree pointer so git prune doesn't orphan it
+  if [ -d "$REPO_GIT/worktrees/$WORKTREE_NAME" ]; then
+    echo "gitdir: $REPO_GIT/worktrees/$WORKTREE_NAME" > "$WORKTREE/.git"
+    echo "$WORKTREE/.git" > "$REPO_GIT/worktrees/$WORKTREE_NAME/gitdir"
+  fi
 }
 trap cleanup_monitor EXIT
 
@@ -371,9 +376,5 @@ EXIT_CODE=${PIPESTATUS[0]}
 echo "" >&2
 echo "Finished: $(date -u +%Y-%m-%dT%H:%M:%SZ)" >&2
 echo "Exit code: $EXIT_CODE" >&2
-
-# -- Restore host worktree pointer ---------------------------------------------
-echo "gitdir: $REPO_GIT/worktrees/$WORKTREE_NAME" > "$WORKTREE/.git"
-echo "$WORKTREE/.git" > "$REPO_GIT/worktrees/$WORKTREE_NAME/gitdir"
 
 exit $EXIT_CODE

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -332,6 +332,10 @@ function parseClaudeOutput(logContent: string, skipLinesBefore = 0): ParsedOutpu
       maxTurnsReached = true;
     }
 
+    if (parsed.type === "result" && parsed.subtype === "success") {
+      lastError = null;
+    }
+
     // JSON error objects (e.g. {"type":"error","message":"..."})
     if (parsed.type === "error" && parsed.message) {
       lastError = String(parsed.message).slice(0, 300);


### PR DESCRIPTION
## Summary
- Move worktree pointer restoration into the `EXIT` trap so it always runs even on crash/timeout, not just on clean exit
- Clear `lastError` when a `result/success` entry is parsed, preventing a prior transient error from being surfaced as the final error

## Test plan
- [x] Run a task to completion — worktree `.git` file is intact after container exits
- [x] Run a task that hits a recoverable error mid-session then succeeds — no error shown in UI