### PR TITLE
feat(runtime): runTask returns TaskHandle immediately after spawn

### DIFF
--- a/container/sandbox-run.sh
+++ b/container/sandbox-run.sh
@@ -103,8 +103,14 @@ MISE_VOLUME="${MISE_VOLUME:-mise-installs}"
 # SHADOW_DIRS is a space-separated list of workspace-relative dirs to shadow with
 # per-task named volumes.  Default: node_modules (backward compatible).
 SHADOW_MOUNTS=""
+FIRST_SHADOW=1
 for dir in ${SHADOW_DIRS:-node_modules}; do
-  vol="shadow-$(echo "$dir" | tr '/' '-')-${TASK_ID}"
+  if [ "$FIRST_SHADOW" = "1" ] && [ -n "${DEP_CACHE_VOLUME:-}" ]; then
+    vol="${DEP_CACHE_VOLUME}"
+  else
+    vol="shadow-$(echo "$dir" | tr '/' '-')-${TASK_ID}"
+  fi
+  FIRST_SHADOW=0
   podman volume exists "$vol" 2>/dev/null || podman volume create "$vol" >/dev/null
   SHADOW_MOUNTS="$SHADOW_MOUNTS --mount type=volume,src=$vol,dst=/workspace/$dir"
 done

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
           { text: "Network Policies", link: "/guides/network" },
           { text: "Review Tasks", link: "/guides/review-tasks" },
           { text: "Providers", link: "/guides/providers" },
+          { text: "Dependency Cache", link: "/guides/dep-cache" },
           { text: "Symphony Integration", link: "/guides/symphony" },
           { text: "ysa vs OpenShell", link: "/guides/openshell" },
         ],

--- a/docs/api/run-task.md
+++ b/docs/api/run-task.md
@@ -5,28 +5,63 @@ Run a coding task inside a sandboxed container.
 ## Signature
 
 ```ts
-function runTask(config: RunConfig, options?: RunOptions): Promise<RunResult>
+function runTask(config: RunConfig, options?: RunOptions): Promise<TaskHandle>
 ```
 
 ```ts
 interface RunOptions {
   onProgress?: (message: string) => void;
   onEvent?: (event: ParsedLogEntry) => void;
+  onComplete?: (result: RunResult) => void;  // fired when container exits
+  onError?: (error: Error) => void;          // fired for infrastructure failures (spawn, volume setup)
+}
+
+interface TaskHandle {
+  taskId: string;
+  logPath: string;
+  shadowVolumes: string[];   // dep cache volumes — available immediately after spawn
+  wait(): Promise<RunResult>;
+  stop(): Promise<void>;
 }
 ```
+
+`runTask` returns a `TaskHandle` **immediately after the container spawns** — the container may still be running. Use `handle.wait()` to block until completion (same as the old behaviour), or pass `onComplete` to be notified asynchronously.
+
+`onError` fires only for infrastructure failures before/during spawn (can't create volume, sandbox won't start). `handle.wait()` always resolves — it never rejects. Task-level failures (max turns, agent abort, non-zero exit) come through `onComplete`/`wait()` with the appropriate `status` and `failure_reason`.
 
 ## Minimal example
 
 ```ts
 import { runTask } from "@ysa-ai/ysa/runtime";
 
-const result = await runTask({
+const handle = await runTask({
   taskId: crypto.randomUUID(),
   prompt: "refactor the database connection pool",
   branch: "refactor/db-pool",
   projectRoot: "/home/user/myapp",
   worktreePrefix: "/home/user/myapp/.ysa/worktrees/",
 });
+
+const result = await handle.wait();
+```
+
+## Non-blocking example
+
+```ts
+const handle = await runTask(config, {
+  onComplete: (result) => {
+    console.log("done:", result.status);
+  },
+  onError: (err) => {
+    console.error("spawn failed:", err.message);
+  },
+});
+
+// handle.shadowVolumes available here — before container finishes
+console.log("volumes:", handle.shadowVolumes);
+
+// Stop from a signal handler or timeout
+process.once("SIGINT", () => handle.stop());
 ```
 
 ## RunConfig fields
@@ -48,6 +83,8 @@ const result = await runTask({
 | `networkPolicy` | `"none"\|"strict"` | `"none"` | Container network policy. See [Network guide](/guides/network) |
 | `promptUrl` | `string` | — | URL the container fetches the prompt from (used by the platform) |
 | `shadowDirs` | `string[]` | `["node_modules"]` | Directories shadowed with per-task volumes |
+| `depInstallCmd` | `string` | — | Command to install dependencies before starting the agent (e.g. `"bun install"`). Runs in an isolated container and installs into the shadow volume, so dependencies are available when the agent starts |
+| `depsCacheKey` | `string` | — | Stable cache key for the deps shadow volume. When set, the volume is named `shadow-<dir>-<depsCacheKey>` and reused across tasks with the same key — skipping reinstall if the volume already exists. Pass a hash of your lockfiles to invalidate the cache when deps change |
 | `miseVolume` | `string` | — | Pre-populated mise-installs volume to mount |
 | `worktreeFiles` | `string[]` | — | Untracked files to copy from project root into the worktree |
 | `extraEnv` | `Record<string, string>` | — | Extra environment variables injected into the container |

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -49,6 +49,8 @@ interface RunConfig {
   networkPolicy?: "none" | "strict";
   promptUrl?: string;
   shadowDirs?: string[];
+  depInstallCmd?: string;
+  depsCacheKey?: string;
   miseVolume?: string;
   worktreeFiles?: string[];
   extraEnv?: Record<string, string>;
@@ -59,9 +61,34 @@ interface RunConfig {
 }
 ```
 
+## TaskHandle
+
+Returned immediately by `runTask()` — container may still be running:
+
+```ts
+interface TaskHandle {
+  taskId: string;
+  logPath: string;
+  shadowVolumes: string[];   // dep cache volumes (stable across tasks with same depsCacheKey)
+  wait(): Promise<RunResult>;
+  stop(): Promise<void>;
+}
+```
+
+## RunOptions
+
+```ts
+interface RunOptions {
+  onProgress?: (message: string) => void;
+  onEvent?: (event: ParsedLogEntry) => void;
+  onComplete?: (result: RunResult) => void;
+  onError?: (error: Error) => void;
+}
+```
+
 ## RunResult
 
-What `runTask()` returns:
+What `handle.wait()` / `onComplete` delivers:
 
 ```ts
 interface RunResult {

--- a/docs/guides/dep-cache.md
+++ b/docs/guides/dep-cache.md
@@ -1,0 +1,92 @@
+# Dependency Cache
+
+Each task runs in a fresh container, but installing dependencies from scratch on every task is slow. The dep cache lets you pre-install dependencies into a named Podman volume that is reused across tasks — as long as the lockfiles haven't changed.
+
+## How it works
+
+1. Before the agent container starts, ysa runs `depInstallCmd` in a temporary container mounted against the project worktree.
+2. The installed dependencies land in a shadow volume (`shadow-<dir>-<cacheKey>`).
+3. That volume is mounted into the agent container at `/workspace/<shadowDir>` — so dependencies are available immediately when the agent starts.
+4. On subsequent tasks with the same `depsCacheKey`, the volume already exists and the install step is skipped entirely.
+5. When the key changes (lockfile updated), a new volume is created and the old one is cleaned up on the next task spawn.
+
+## Minimal example
+
+```ts
+import { createHash } from "crypto";
+import { readFileSync } from "fs";
+
+const lockHash = createHash("sha1")
+  .update(readFileSync("bun.lockb"))
+  .digest("hex")
+  .slice(0, 16);
+
+const handle = await runTask({
+  taskId: crypto.randomUUID(),
+  prompt: "add tests for the auth module",
+  branch: "main",
+  projectRoot: "/home/user/myapp",
+  worktreePrefix: "/home/user/myapp/.ysa/worktrees/",
+  depInstallCmd: "bun install",
+  depsCacheKey: lockHash,
+});
+```
+
+## Fields
+
+| Field | Description |
+|-------|-------------|
+| `depInstallCmd` | Command to run inside the container to install dependencies (e.g. `"bun install"`, `"npm ci"`, `"pip install -r requirements.txt"`). Runs before the agent starts. |
+| `depsCacheKey` | Stable string that identifies the current dep state. When this key matches an existing volume, install is skipped. Pass a hash of your lockfiles so the cache invalidates when deps change. |
+| `shadowDirs` | Directories to shadow with per-task volumes. Defaults to `["node_modules"]`. The first entry is where `depInstallCmd` installs into. |
+
+## Volume naming
+
+Volumes are named `shadow-<dir>-<depsCacheKey>`, where `<dir>` is the first entry in `shadowDirs` with slashes replaced by dashes. For example:
+
+- `shadowDirs: ["node_modules"]`, `depsCacheKey: "a1b2c3d4e5f6a7b8"` → `shadow-node_modules-a1b2c3d4e5f6a7b8`
+- `shadowDirs: ["vendor/bundle"]`, `depsCacheKey: "a1b2c3d4e5f6a7b8"` → `shadow-vendor-bundle-a1b2c3d4e5f6a7b8`
+
+`handle.shadowVolumes` contains the exact volume names used by the task — available immediately after spawn, before the container finishes. This lets an orchestration layer record which volumes are in use and clean up stale ones safely.
+
+## Stale volume cleanup
+
+When you run many tasks over time, old dep cache volumes accumulate. The recommended pattern for orchestrators:
+
+1. After `runTask` returns the handle, store `handle.shadowVolumes` (the current task's volumes).
+2. Query your task store for volumes used by other running or recently stopped tasks.
+3. List all Podman volumes matching `shadow-*-<16 hex chars>`.
+4. Remove any that aren't in the protected set.
+
+```ts
+const handle = await runTask(config, { onComplete, onError });
+
+// Store volumes before container finishes
+const currentVolumes = handle.shadowVolumes;
+await storeTaskVolumes(handle.taskId, currentVolumes);
+
+// Clean stale volumes (don't remove anything still in use)
+const inUse = await getVolumesInUse(); // from your task store
+const protectedSet = new Set([...currentVolumes, ...inUse]);
+const allVolumes = await listPodmanVolumes();
+for (const vol of allVolumes) {
+  if (/^shadow-.*-[a-f0-9]{16}$/.test(vol) && !protectedSet.has(vol)) {
+    await podman("volume", "rm", vol);
+  }
+}
+```
+
+## Caching multiple directories
+
+To cache more than one directory (e.g. both `node_modules` and `.cache`):
+
+```ts
+const handle = await runTask({
+  // ...
+  depInstallCmd: "bun install",
+  depsCacheKey: lockHash,
+  shadowDirs: ["node_modules", ".cache"],
+});
+```
+
+Only the first directory in `shadowDirs` is used for the dep cache volume. Additional directories get per-task volumes (not shared across tasks).

--- a/src/cli/commands/refine.ts
+++ b/src/cli/commands/refine.ts
@@ -80,7 +80,7 @@ export async function refineCommand(
     return;
   }
 
-  const result = await runTask(config, {
+  const handle = await runTask(config, {
     onProgress: (msg) => {
       if (!opts.quiet) console.log(`  \x1b[90m${msg}\x1b[0m`);
     },
@@ -88,6 +88,8 @@ export async function refineCommand(
       if (!opts.quiet) renderEvent(entry, !!opts.verbose);
     },
   });
+  process.once("SIGINT", () => { handle.stop().catch(() => {}); });
+  const result = await handle.wait();
 
   console.log();
   if (result.status === "completed") {

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -86,7 +86,7 @@ export async function runCommand(
   };
 
   const runWithStreaming = async (runConfig: RunConfig) => {
-    return runTask(runConfig, {
+    const handle = await runTask(runConfig, {
       onProgress: (msg) => {
         if (!opts.quiet) console.log(`  \x1b[90m${msg}\x1b[0m`);
       },
@@ -94,6 +94,8 @@ export async function runCommand(
         if (!opts.quiet) renderEvent(entry, !!opts.verbose);
       },
     });
+    process.once("SIGINT", () => { handle.stop().catch(() => {}); });
+    return handle.wait();
   };
 
   const result = await runWithStreaming(config);

--- a/src/runtime/container.ts
+++ b/src/runtime/container.ts
@@ -302,6 +302,7 @@ export interface SpawnSandboxOpts {
   extraPodEnv?: string;       // opaque "-e KEY=val -e KEY2=val2" string forwarded verbatim to podman run
   extraLabels?: Record<string, string>; // extra podman labels added to the container (caller-defined, for filtering)
   shadowDirs?: string[];      // forwarded as SHADOW_DIRS env var to sandbox-run.sh
+  depCacheVolume?: string;    // pre-populated dep cache volume to use for the first shadow dir
   miseVolume?: string;        // name of the pre-populated mise-installs volume to mount
   sessionVolume?: string;     // override session volume name (for resume/refine across containers)
   interactive?: boolean;      // attach stdin/tty for direct terminal use
@@ -317,6 +318,7 @@ export async function spawnSandbox(opts: SpawnSandboxOpts) {
   if (opts.agentImage) env.AGENT_IMAGE = opts.agentImage;
   if (opts.extraPodEnv) env.EXTRA_POD_ENV = opts.extraPodEnv;
   if (opts.shadowDirs && opts.shadowDirs.length > 0) env.SHADOW_DIRS = opts.shadowDirs.join(" ");
+  if (opts.depCacheVolume) env.DEP_CACHE_VOLUME = opts.depCacheVolume;
   if (opts.miseVolume) env.MISE_VOLUME = opts.miseVolume;
   if (opts.sessionVolume) env.SESSION_VOLUME = opts.sessionVolume;
   if (opts.interactive) env.INTERACTIVE = "1";

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,4 +1,5 @@
 export { runTask } from "./runner";
+export type { RunOptions } from "./runner";
 export { runInteractive } from "./interactive";
 export { getAuthEnv } from "./auth";
 export { createWorktree, removeWorktree, prepareWorktree } from "./worktree";

--- a/src/runtime/runner.ts
+++ b/src/runtime/runner.ts
@@ -2,21 +2,27 @@ import { readFile, stat, mkdir, appendFile } from "fs/promises";
 import { join, basename } from "path";
 import { getProvider } from "../providers";
 import { createWorktree, removeWorktree, prepareWorktree } from "./worktree";
-import { spawnSandbox, buildProjectImage, projectImageName, getImagePackagesHash } from "./container";
+import { spawnSandbox, stopContainer, buildProjectImage, projectImageName, getImagePackagesHash, installDepsInShadow } from "./container";
 import { ensureProxy } from "./proxy";
 import { ensureMiseRuntimes } from "./mise";
 import { getOrCreateAuthToken } from "./prompt-token";
 import { readYsaConfig } from "../cli/ysa-config";
-import type { RunConfig, RunResult, TaskStatus } from "../types";
+import type { RunConfig, RunResult, TaskStatus, TaskHandle } from "../types";
 import type { ParsedLogEntry } from "../providers/types";
 
 export interface RunOptions {
   onProgress?: (message: string) => void;
   onEvent?: (event: ParsedLogEntry) => void;
+  onComplete?: (result: RunResult) => void;
+  onError?: (error: Error) => void;
 }
 
 function progressEntry(message: string): string {
   return JSON.stringify({ type: "system", subtype: "progress", message }) + "\n";
+}
+
+function stoppableEntry(value: boolean): string {
+  return JSON.stringify({ type: "system", subtype: "stoppable", value }) + "\n";
 }
 
 async function fileExists(path: string): Promise<boolean> {
@@ -26,6 +32,12 @@ async function fileExists(path: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function computeShadowVolumeNames(config: RunConfig): string[] {
+  if (!config.depsCacheKey || !config.depInstallCmd) return [];
+  const shadowDir = (config.shadowDirs ?? ["node_modules"])[0] ?? "node_modules";
+  return [`shadow-${shadowDir.replace(/\//g, "-")}-${config.depsCacheKey}`];
 }
 
 // Tail a log file, yielding complete lines as they appear.
@@ -76,41 +88,73 @@ async function* tailLog(
   }
 }
 
-export async function runTask(config: RunConfig, opts?: RunOptions): Promise<RunResult> {
+export async function runTask(config: RunConfig, opts?: RunOptions): Promise<TaskHandle> {
   const taskId = config.taskId;
   const worktree = config.resumeWorktree ?? `${config.worktreePrefix}${taskId}`;
   const branch = config.branch ?? `task/${taskId.slice(0, 8)}`;
   const gitDir = join(config.projectRoot, ".git");
   const logDir = join(config.projectRoot, ".ysa", "logs");
   const logPath = join(logDir, `${taskId}.log`);
+  const startTime = Date.now();
 
   const emitProgress = (msg: string) => {
     opts?.onProgress?.(msg);
   };
 
+  // Eagerly compute shadow volume names — available on handle before container exits
+  const shadowVolumes = computeShadowVolumeNames(config);
+
+  // Promise/resolve pair — resultPromise never rejects
+  let resolveResult!: (r: RunResult) => void;
+  const resultPromise = new Promise<RunResult>(r => { resolveResult = r; });
+
+  const completeWith = (result: RunResult) => {
+    resolveResult(result);
+    queueMicrotask(() => opts?.onComplete?.(result));
+  };
+
+  const failWith = (error: Error) => {
+    const result: RunResult = {
+      task_id: taskId,
+      status: "failed",
+      session_id: null,
+      error: error.message,
+      failure_reason: "infrastructure",
+      log_path: logPath,
+      duration_ms: Date.now() - startTime,
+    };
+    resolveResult(result);
+    queueMicrotask(() => opts?.onError?.(error));
+  };
+
+  let intentionallyStopped = false;
+
+  const handle: TaskHandle = {
+    taskId,
+    logPath,
+    shadowVolumes,
+    wait: () => resultPromise,
+    stop: async () => {
+      intentionallyStopped = true;
+      await stopContainer(taskId, { logPath, labels: config.extraLabels });
+    },
+  };
+
   await mkdir(logDir, { recursive: true });
   await mkdir(config.worktreePrefix, { recursive: true });
 
-  // 1. Create worktree (skip if resuming - worktree already exists)
+  // 1. Create worktree (skip if resuming)
   if (!config.resumeSessionId && !config.resumeWorktree) {
     await appendFile(logPath, progressEntry("Creating git worktree..."));
     emitProgress("Creating git worktree...");
-    // Remove stale worktree from a previous failed/stopped run before recreating
     await removeWorktree(config.projectRoot, worktree, branch).catch(() => {});
     const wt = await createWorktree(config.projectRoot, worktree, branch);
     if (!wt.ok) {
-      return {
-        task_id: taskId,
-        status: "failed",
-        session_id: null,
-        error: `Worktree failed: ${wt.error}`,
-        failure_reason: "infrastructure",
-        log_path: logPath,
-        duration_ms: 0,
-      };
+      failWith(new Error(`Worktree failed: ${wt.error}`));
+      return handle;
     }
 
-    // 2. Prepare worktree (copy .mcp.json, env files, worktree files)
+    // 2. Prepare worktree
     await prepareWorktree(worktree, config.projectRoot, undefined, undefined, config.worktreeFiles);
   }
 
@@ -118,7 +162,7 @@ export async function runTask(config: RunConfig, opts?: RunOptions): Promise<Run
   const adapter = getProvider(config.provider ?? "claude");
   const authEnv = await adapter.getAuthEnv();
 
-  // 4. Build auth env flags string for sandbox (passed as AGENT_AUTH_ENV_FLAGS)
+  // 4. Build auth env flags string
   const agentAuthEnvFlags = adapter.authEnvKeys
     .filter((key) => authEnv[key])
     .map((key) => `-e ${key}`)
@@ -151,27 +195,20 @@ export async function runTask(config: RunConfig, opts?: RunOptions): Promise<Run
       emitProgress("Building project sandbox image...");
       const built = await buildProjectImage(aptPackages, projImage, adapter.containerImage, adapter.packageManager, (line) => emitProgress(line));
       if (!built.ok) {
-        return {
-          task_id: taskId,
-          status: "failed",
-          session_id: null,
-          error: `Image build failed: ${built.error}`,
-          failure_reason: "infrastructure",
-          log_path: logPath,
-          duration_ms: 0,
-        };
+        failWith(new Error(`Image build failed: ${built.error}`));
+        return handle;
       }
     }
     agentImage = projImage;
   }
 
-  // 8. Proxy auto-start (issue #40)
+  // 8. Proxy auto-start
   if (config.networkPolicy === "strict") {
     emitProgress("Starting network proxy...");
     await ensureProxy(config.proxyRules, undefined, config.serverPort);
   }
 
-  // 9. Mise pre-install (issue #39) — use .ysa.toml runtimes, fall back to file detection
+  // 9. Mise pre-install
   const miseVolume =
     config.miseVolume ??
     (await ensureMiseRuntimes(
@@ -181,43 +218,86 @@ export async function runTask(config: RunConfig, opts?: RunOptions): Promise<Run
       ysaConfig.sandbox?.runtimes,
     ));
 
-  // 10. Spawn sandbox
-  const startTime = Date.now();
+  // 10. Install dependencies into shadow volume (if depInstallCmd is set)
+  let depCacheVolume: string | undefined;
+  if (config.depInstallCmd) {
+    const shadowDir = (config.shadowDirs ?? ["node_modules"])[0] ?? "node_modules";
+    const shadowVolume = config.depsCacheKey
+      ? `shadow-${shadowDir.replace(/\//g, "-")}-${config.depsCacheKey}`
+      : `shadow-${shadowDir.replace(/\//g, "-")}-${taskId}`;
+
+    const volumeExists = config.depsCacheKey
+      ? (await Bun.spawn(["podman", "volume", "exists", shadowVolume]).exited) === 0
+      : false;
+
+    if (volumeExists) {
+      await appendFile(logPath, progressEntry("Dependencies loaded from cache"));
+      emitProgress("Dependencies loaded from cache");
+    } else {
+      await appendFile(logPath, stoppableEntry(false));
+      await appendFile(logPath, progressEntry("Installing dependencies..."));
+      emitProgress("Installing dependencies...");
+      const installResult = await installDepsInShadow({
+        worktree,
+        installCmd: config.depInstallCmd,
+        shadowVolume,
+        shadowDir,
+        image: agentImage,
+        miseVolume,
+      });
+      if (!installResult.ok) {
+        failWith(new Error(`Dependency install failed: ${installResult.error}`));
+        return handle;
+      }
+      await appendFile(logPath, stoppableEntry(true));
+    }
+
+    // Pass the pre-populated volume to sandbox-run.sh so it uses it instead of creating a fresh one
+    if (config.depsCacheKey) depCacheVolume = shadowVolume;
+  }
+
+  // 11. Spawn sandbox
   const env: Record<string, string> = { ...authEnv, ...containerConfig.envVars, ...config.extraEnv };
   if (config.promptUrl) env.PROMPT_URL = config.promptUrl;
   env.PROMPT_TOKEN = getOrCreateAuthToken();
 
-  // When resuming, reuse the original task's session volume so Claude can find the conversation
   const sessionVolume = config.resumeWorktree
     ? `task-session-${basename(config.resumeWorktree)}`
     : undefined;
 
   emitProgress("Starting agent...");
-  const proc = await spawnSandbox({
-    worktree,
-    gitDir,
-    branch,
-    mode: config.allowCommit === false ? "readonly" : "readwrite",
-    id: taskId,
-    cliArgs,
-    env,
-    logPath,
-    networkPolicy: config.networkPolicy,
-    agentBinary: adapter.agentBinary,
-    agentImage,
-    agentInitScript: containerConfig.initScript,
-    agentAuthEnvFlags,
-    extraPodEnv: [
-      `-e CONTEXT_ID=${taskId}`,
-      ...Object.entries(config.extraEnv ?? {}).map(([k, v]) => `-e ${k}=${v}`),
-    ].join(" "),
-    extraLabels: config.extraLabels,
-    shadowDirs: config.shadowDirs,
-    miseVolume,
-    sessionVolume,
-  });
+  let proc: Awaited<ReturnType<typeof spawnSandbox>>;
+  try {
+    proc = await spawnSandbox({
+      worktree,
+      gitDir,
+      branch,
+      mode: config.allowCommit === false ? "readonly" : "readwrite",
+      id: taskId,
+      cliArgs,
+      env,
+      logPath,
+      networkPolicy: config.networkPolicy,
+      agentBinary: adapter.agentBinary,
+      agentImage,
+      agentInitScript: containerConfig.initScript,
+      agentAuthEnvFlags,
+      extraPodEnv: [
+        `-e CONTEXT_ID=${taskId}`,
+        ...Object.entries(config.extraEnv ?? {}).map(([k, v]) => `-e ${k}=${v}`),
+      ].join(" "),
+      extraLabels: config.extraLabels,
+      shadowDirs: config.shadowDirs,
+      depCacheVolume,
+      miseVolume,
+      sessionVolume,
+    });
+  } catch (err) {
+    failWith(err instanceof Error ? err : new Error(String(err)));
+    return handle;
+  }
 
-  // 11. Stream log output in real time (issue #41)
+  // 12. Stream log output in real time
   const exitedPromise = proc.exited;
   if (opts?.onEvent || opts?.onProgress) {
     (async () => {
@@ -230,46 +310,63 @@ export async function runTask(config: RunConfig, opts?: RunOptions): Promise<Run
     })();
   }
 
-  const exitCode = await exitedPromise;
-  const durationMs = Date.now() - startTime;
+  // Background: wait for container exit, parse result, fire onComplete
+  (async () => {
+    try {
+      const exitCode = await exitedPromise;
+      const durationMs = Date.now() - startTime;
 
-  // 12. Parse output
-  const parsed = await fileExists(logPath)
-    ? adapter.parseOutput(await readFile(logPath, "utf-8"))
-    : { sessionId: null, maxTurnsReached: false, agentAborted: false, abortReason: null, lastError: null };
+      const parsed = await fileExists(logPath)
+        ? adapter.parseOutput(await readFile(logPath, "utf-8"))
+        : { sessionId: null, maxTurnsReached: false, agentAborted: false, abortReason: null, lastError: null };
 
-  // 13. Determine result
-  let status: TaskStatus;
-  let error: string | null = null;
-  let failureReason: "max_turns" | "infrastructure" | "agent_aborted" | null = null;
+      if (intentionallyStopped) {
+        completeWith({
+          task_id: taskId,
+          status: "stopped",
+          session_id: parsed.sessionId,
+          error: null,
+          failure_reason: null,
+          log_path: logPath,
+          duration_ms: durationMs,
+        });
+        return;
+      }
 
-  if (parsed.agentAborted) {
-    status = "failed";
-    error = parsed.abortReason || "Agent aborted the task";
-    failureReason = "agent_aborted";
-  } else if (parsed.maxTurnsReached) {
-    status = "failed";
-    error = `Max turns (${config.maxTurns ?? 60}) reached.`;
-    failureReason = "max_turns";
-  } else if (exitCode === 0 || (!parsed.lastError && (config.provider ?? "claude") === "claude")) {
-    // exitCode !== 0 with no lastError (Claude only) is a known false positive: Claude writes to
-    // settings.json (mounted :ro for security) at session end and exits with code 1.
-    // Since the work completed without errors, treat it as success.
-    status = "completed";
-  } else {
-    status = "failed";
-    failureReason = "infrastructure";
-    error = `Agent exited with code ${exitCode}`;
-    if (parsed.lastError) error += `. ${parsed.lastError}`;
-  }
+      let status: TaskStatus;
+      let error: string | null = null;
+      let failureReason: "max_turns" | "infrastructure" | "agent_aborted" | null = null;
 
-  return {
-    task_id: taskId,
-    status,
-    session_id: parsed.sessionId,
-    error,
-    failure_reason: failureReason,
-    log_path: logPath,
-    duration_ms: durationMs,
-  };
+      if (parsed.agentAborted) {
+        status = "failed";
+        error = parsed.abortReason || "Agent aborted the task";
+        failureReason = "agent_aborted";
+      } else if (parsed.maxTurnsReached) {
+        status = "failed";
+        error = `Max turns (${config.maxTurns ?? 60}) reached.`;
+        failureReason = "max_turns";
+      } else if (exitCode === 0 || (!parsed.lastError && (config.provider ?? "claude") === "claude")) {
+        status = "completed";
+      } else {
+        status = "failed";
+        failureReason = "infrastructure";
+        error = `Agent exited with code ${exitCode}`;
+        if (parsed.lastError) error += `. ${parsed.lastError}`;
+      }
+
+      completeWith({
+        task_id: taskId,
+        status,
+        session_id: parsed.sessionId,
+        error,
+        failure_reason: failureReason,
+        log_path: logPath,
+        duration_ms: durationMs,
+      });
+    } catch (err) {
+      failWith(err instanceof Error ? err : new Error(String(err)));
+    }
+  })();
+
+  return handle;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,8 @@ export interface RunConfig {
   networkPolicy?: "none" | "strict" | "custom"; // default "none"
   promptUrl?: string; // URL for container to fetch prompt from
   shadowDirs?: string[]; // dirs to shadow with per-task volumes (default: ["node_modules"])
+  depInstallCmd?: string; // command to install dependencies before starting the agent (e.g. "bun install")
+  depsCacheKey?: string; // stable key for the deps shadow volume — same key reuses the volume and skips reinstall
   miseVolume?: string;  // pre-populated mise-installs volume to mount (set at project settings save time)
   worktreeFiles?: string[]; // untracked files to copy from project root into worktree
   extraEnv?: Record<string, string>; // extra env vars injected into the container (e.g. DASHBOARD_URL, ISSUE_ID)
@@ -40,6 +42,15 @@ export interface RunConfig {
   proxyRules?: import("./runtime/proxy").ScopedAllowRule[]; // per-task scoped proxy allow rules
   serverPort?: number; // host server port to bypass in proxy (e.g. dashboard port)
   allowCommit?: boolean; // whether the agent can commit to git (default: true)
+}
+
+// Handle returned immediately by runTask() — container may still be running
+export interface TaskHandle {
+  taskId: string;
+  logPath: string;
+  shadowVolumes: string[];   // dep cache volumes (stable across tasks with same depsCacheKey)
+  wait(): Promise<RunResult>;
+  stop(): Promise<void>;
 }
 
 // What runTask() returns


### PR DESCRIPTION
## Summary

- `runTask` now returns `Promise<TaskHandle>` immediately after the container spawns — no longer blocks until completion
- `TaskHandle` exposes `taskId`, `logPath`, `shadowVolumes`, `wait()`, `stop()`
- `onComplete`/`onError` callbacks added to `RunOptions` for async completion handling
- `stop()` sets an `intentionallyStopped` flag so `onComplete` fires with `status: "stopped"` + `session_id` (not a guessed exit-code status)
- `DEP_CACHE_VOLUME` env var properly wires the pre-populated dep cache volume into the sandbox container (was broken before — container was creating a fresh volume instead of using the cache)
- Dep cache guide added to docs

## Migration

Callers wanting the old blocking behavior:
```ts
// before
const result = await runTask(config);

// after
const handle = await runTask(config);
const result = await handle.wait();
```