### PR TITLE
fix: simplify tool preset handling and fix interactive branch

### DIFF
--- a/container/sandbox-run.sh
+++ b/container/sandbox-run.sh
@@ -36,11 +36,11 @@ ALLOWED_BRANCH="$3"
 MODE="$4"
 TASK_ID="$5"
 shift 5
-# Extract --allowedTools value (used to write MCP permissions into container settings)
+# Extract --tools value (used to write MCP permissions into container settings)
 ALLOWED_TOOLS_VALUE=""
 PREV_ARG=""
 for arg in "$@"; do
-  if [ "$PREV_ARG" = "--allowedTools" ]; then
+  if [ "$PREV_ARG" = "--tools" ]; then
     ALLOWED_TOOLS_VALUE="$arg"
     break
   fi
@@ -236,7 +236,7 @@ fi
 # -- Generate read-only settings.json on host --------------------------------
 # settings.json is mounted :ro so the agent cannot modify the hook reference.
 # Claude Code does not write to settings.json during normal operation (confirmed).
-# ALLOWED_TOOLS injection is best-effort: if jq is unavailable, the --allowedTools
+# ALLOWED_TOOLS injection is best-effort: if jq is unavailable, the --tools
 # CLI flag already enforces restrictions and the injection is redundant.
 SETTINGS_TMP=$(mktemp)
 if [ -n "$ALLOWED_TOOLS_VALUE" ] && command -v jq >/dev/null 2>&1; then

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -417,7 +417,13 @@ function buildClaudeCommand(opts: CommandOpts): string[] {
   }
 
   if (opts.allowedTools) {
-    args.push("--allowedTools", opts.allowedTools);
+    const tools = opts.allowedTools.split(",").filter((t) => t !== "mcp__*").join(",");
+    if (tools) args.push("--tools", tools);
+    if (!opts.allowedTools.includes("mcp__")) {
+      args.push("--strict-mcp-config");
+    }
+  } else {
+    args.push("--strict-mcp-config");
   }
 
   if (opts.model) {

--- a/src/runtime/interactive.ts
+++ b/src/runtime/interactive.ts
@@ -9,8 +9,7 @@ import type { RunConfig } from "../types";
 export async function runInteractive(config: RunConfig): Promise<void> {
   const taskId = config.taskId;
   const worktree = config.resumeWorktree ?? `${config.worktreePrefix}${taskId}`;
-  const branch = `task/${taskId.slice(0, 8)}`;
-  const baseBranch = config.branch;
+  const branch = config.branch;
   const gitDir = join(config.projectRoot, ".git");
   const logDir = join(config.projectRoot, ".ysa", "logs");
 
@@ -19,7 +18,7 @@ export async function runInteractive(config: RunConfig): Promise<void> {
 
   if (!config.resumeSessionId && !config.resumeWorktree) {
     await removeWorktree(config.projectRoot, worktree, branch).catch(() => {});
-    const wt = await createWorktree(config.projectRoot, worktree, branch, baseBranch);
+    const wt = await createWorktree(config.projectRoot, worktree, branch);
     if (!wt.ok) {
       console.error(`Worktree failed: ${wt.error}`);
       process.exit(1);


### PR DESCRIPTION
## Summary

- Replace `--allowedTools` with `--tools` (Claude CLI only accepts base tool names, not patterns)
- Add `--strict-mcp-config` when no MCP tools in allowlist; strip `mcp__*` sentinel before passing to `--tools`
- Fix interactive mode using hardcoded `task/` prefix instead of `config.branch`

## Test plan
- [x] Run a task with default readonly step — all default tools available
- [x] Run a task with readwrite step — agent can commit and push
- [x] MCP toggle ON with no restriction — no `--strict-mcp-config`, no `--tools`
- [x] Interactive session uses correct branch from project config