### PR TITLE
fix(oauth): extract production client ID from Claude binary for token refresh

### DIFF
--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -33,8 +33,9 @@ async function extractClientIdFromBinary(): Promise<string | null> {
     const binPath = (await new Response(readlink.stdout).text()).trim();
     if ((await readlink.exited) !== 0 || !binPath) return null;
 
+    // Extract the production client ID (OAUTH_FILE_SUFFIX:"") — not the local dev one
     const extract = Bun.spawn(
-      ["bash", "-c", `grep -oaE 'CLIENT_ID:"[0-9a-f-]+"' "${binPath}" 2>/dev/null | head -1 | sed 's/CLIENT_ID:"//;s/"//'`],
+      ["bash", "-c", `grep -oaE 'CLIENT_ID:"[0-9a-f-]+",OAUTH_FILE_SUFFIX:""' "${binPath}" 2>/dev/null | head -1 | grep -oE '"[0-9a-f-]+"' | head -1 | tr -d '"'`],
       { stdout: "pipe", stderr: "pipe" },
     );
     const clientId = (await new Response(extract.stdout).text()).trim();


### PR DESCRIPTION
## Summary

- The Claude binary embeds two OAuth client IDs: a local/dev one (`OAUTH_FILE_SUFFIX: "-local-..."`) and the production one (`OAUTH_FILE_SUFFIX: ""`)
- Previous grep pattern matched `head -1` which always picked the local dev client ID
- This caused token refresh requests to fail with `invalid_request_error` → `oauth_client_stale`
- Fix: narrow the grep pattern to only match the entry with an empty `OAUTH_FILE_SUFFIX`