### PR TITLE
feat: DeepSeek provider, ysa key, bypassHosts, sandbox config, container fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ src/
   db/            — Drizzle schema + migrations (~/.ysa/core.db)
   dashboard/     — React components (props-based, no internal tRPC)
   lib/           — resources, resource-poller
-  providers/     — Claude, Mistral adapters + registry
+  providers/     — Claude, Mistral, DeepSeek adapters + registry
   runtime/       — sandbox orchestration (runner, container, proxy, worktree, auth)
   server/        — Hono app
 client/          — React entry (wires tRPC to dashboard components)
@@ -45,9 +45,23 @@ All config in SQLite (`~/.ysa/core.db`), no `.env` needed. Config table: `projec
 
 Worktrees always at `${project_root}/.ysa/worktrees/`. DB and logs at `${project_root}/.ysa/`.
 
+### `.ysa.toml` — per-project sandbox config
+
+```toml
+[sandbox]
+runtimes = ["node@22", "python@3.12"]   # mise tools pre-installed before agent starts
+packages = ["libpq-dev", "chromium"]    # apt/apk packages baked into a project image layer
+global_packages = ["pip:playwright", "npm:@playwright/mcp@latest"]  # global installs (prefix: pip/npm/gem/cargo/go/bun)
+init_commands = ["redis-server --daemonize yes"]  # commands run inside container before agent
+```
+
+Mise installs cache: `~/.cache/ysa-agent/mise-installs/<hash>/` (host bind-mount, not a Podman volume).
+
 ## Adding a provider
 
 Implement `ProviderAdapter` from `src/providers/types.ts`, register in `src/providers/registry.ts`.
+
+Set `bypassHosts` on the adapter if the provider's API endpoint must be accessed directly (bypasses the proxy and iptables filtering for those hosts). API keys for non-Claude providers are stored via `ysa key set <provider>` and retrieved with `getApiKey(provider)` from `src/cli/keystore`.
 
 ## Migrations
 

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -83,7 +83,7 @@ RUN rm -f /usr/bin/passwd /usr/bin/chage /usr/bin/chfn /usr/bin/chsh \
 # sandbox-guard.sh goes ONLY into /etc/claude-defaults/hooks (read-only image layer)
 # settings.json references /etc/claude-defaults/hooks/sandbox-guard.sh so the agent
 # cannot modify the active hook regardless of what it does to /home/agent
-RUN mkdir -p /home/agent/.claude /etc/claude-defaults/hooks && \
+RUN mkdir -p /home/agent/.claude /usr/local/mise-installs /etc/claude-defaults/hooks && \
     chown -R agent:agent /home/agent/.claude
 COPY claude-settings.json /home/agent/.claude/settings.json
 COPY claude-settings.json /etc/claude-defaults/settings.json

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -33,6 +33,12 @@ COPY vibe-config.toml /etc/vibe-defaults/config.toml
 RUN userdel bun 2>/dev/null || true && \
     groupadd -g 1001 agent && useradd -u 1000 -g agent -m -d /home/agent -s /bin/bash agent
 
+# Remove passwd entries (except root) whose home dir is '/' — prevents getpwuid_r
+# from returning '/' as home for any UID that maps into the container at runtime,
+# which would cause tools to compute read-only paths like /.turbo/cache.
+# When no entry is found, all tools fall back to the HOME env var instead.
+RUN awk -F: 'BEGIN{OFS=":"} !($1!="root" && $6=="/")' /etc/passwd > /tmp/passwd.tmp && mv /tmp/passwd.tmp /etc/passwd
+
 # Workspace (rw — Claude edits code here) and output dirs
 RUN mkdir -p /workspace /output && chown agent:agent /workspace /output
 

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -144,7 +144,8 @@ ENV GIT_CONFIG_COUNT=20 \
 
 # Install mise universal toolchain manager
 RUN curl https://mise.run | sh
-ENV PATH="/home/agent/.local/bin:$PATH"
+ENV PATH="/home/agent/.local/bin:$PATH" \
+    HOME="/home/agent"
 RUN mise --version
 
 # Optional language runtime packages — installed via apt based on project language selection.

--- a/container/container-sandbox-guard.sh
+++ b/container/container-sandbox-guard.sh
@@ -4,7 +4,7 @@
 # Paths:
 #   /workspace  — worktree (rw)
 #   /output     — output directory (rw)
-#   /repo.git   — main repo git dir (ro or rw)
+#   /tmp/repo.git   — main repo git dir (ro or rw)
 #
 # Exit 0 = allow, Exit 2 = block (message in stderr)
 
@@ -18,7 +18,7 @@ fi
 CONTEXT_ID="${CONTEXT_ID:-unknown}"
 WORKTREE="/workspace"
 OUTPUT_DIR="/output"
-MAIN_REPO="/repo.git"
+MAIN_REPO="/tmp/repo.git"
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')

--- a/container/oci-network-hook.sh
+++ b/container/oci-network-hook.sh
@@ -96,13 +96,82 @@ if [ -n "$HCI_IP" ] && [ "$HCI_IP" != "$HOST_IP" ]; then
   $SUDO nsenter -t "$PID" -n iptables -A OUTPUT -p tcp -d "$HCI_IP" --dport "$SERVER_PORT" -j ACCEPT
 fi
 
-# Allow the slirp4netns gateway too — it may differ from HOST_IP and is used for DNS.
-# Also covers the case where proxy/server are reachable via the gateway IP.
+# Allow the slirp4netns gateway too — it may differ from HOST_IP and is used for proxy/server access.
 GATEWAY_IP=$($SUDO nsenter -t "$PID" -n ip route 2>/dev/null | awk '/default/{print $3; exit}') || true
 if [ -n "$GATEWAY_IP" ] && [ "$GATEWAY_IP" != "$HOST_IP" ]; then
   $SUDO nsenter -t "$PID" -n iptables -A OUTPUT -p tcp -d "$GATEWAY_IP" --dport "$PROXY_PORT" -j ACCEPT
   $SUDO nsenter -t "$PID" -n iptables -A OUTPUT -p tcp -d "$GATEWAY_IP" --dport "$SERVER_PORT" -j ACCEPT
-  $SUDO nsenter -t "$PID" -n iptables -A OUTPUT -p udp -d "$GATEWAY_IP" --dport 53 -j ACCEPT
+fi
+
+# Allow DNS to the slirp4netns DNS server (always gateway+1) and to HOST_IP/HCI_IP
+# (macOS Podman Machine also uses HOST_IP as a nameserver).
+# TCP:53 is needed for large DNS responses (e.g. MongoDB SRV records).
+if [ -n "$GATEWAY_IP" ]; then
+  GATEWAY_DNS="${GATEWAY_IP%.*}.$((${GATEWAY_IP##*.} + 1))"
+  $SUDO nsenter -t "$PID" -n iptables -A OUTPUT -p udp -d "$GATEWAY_DNS" --dport 53 -j ACCEPT
+  $SUDO nsenter -t "$PID" -n iptables -A OUTPUT -p tcp -d "$GATEWAY_DNS" --dport 53 -j ACCEPT
+fi
+for dns_host in "$HOST_IP" "${HCI_IP:-}"; do
+  [ -z "$dns_host" ] && continue
+  $SUDO nsenter -t "$PID" -n iptables -A OUTPUT -p udp -d "$dns_host" --dport 53 -j ACCEPT
+  $SUDO nsenter -t "$PID" -n iptables -A OUTPUT -p tcp -d "$dns_host" --dport 53 -j ACCEPT
+done
+
+# Per-project bypass hosts — direct TCP access, skips proxy (for raw TCP protocols like MongoDB)
+BYPASS_HOSTS_VAL=""
+if [ -n "$BUNDLE" ] && [ -f "$BUNDLE/config.json" ]; then
+  BYPASS_HOSTS_VAL=$(jq -r '.process.env[] | select(startswith("BYPASS_HOSTS=")) | ltrimstr("BYPASS_HOSTS=")' "$BUNDLE/config.json" 2>/dev/null | head -1) || true
+fi
+
+if [ -n "$BYPASS_HOSTS_VAL" ]; then
+  OLD_IFS="$IFS"
+  IFS=','
+  for entry in $BYPASS_HOSTS_VAL; do
+    IFS="$OLD_IFS"
+    entry=$(echo "$entry" | tr -d ' ')
+    [ -z "$entry" ] && continue
+    host="${entry%%:*}"
+    port=""
+    if [ "$entry" != "$host" ]; then
+      port="${entry##*:}"
+    fi
+
+    RESOLVED_IPS=""
+
+    if command -v dig >/dev/null 2>&1; then
+      # Direct A record
+      A_IPS=$(dig +short A "$host" 2>/dev/null | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$') || true
+      RESOLVED_IPS="$A_IPS"
+
+      # SRV chain (covers MongoDB and similar cloud DBs where the hostname has no direct A record)
+      SRV_OUT=$(dig +short SRV "_mongodb._tcp.$host" 2>/dev/null) || true
+      if [ -n "$SRV_OUT" ]; then
+        while read -r _pri _wt _sp srv_target; do
+          [ -z "$srv_target" ] && continue
+          srv_target="${srv_target%.}"
+          NODE_IPS=$(dig +short A "$srv_target" 2>/dev/null | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$') || true
+          RESOLVED_IPS="$RESOLVED_IPS $NODE_IPS"
+        done <<EOF
+$SRV_OUT
+EOF
+      fi
+    else
+      RESOLVED_IPS=$(getent hosts "$host" 2>/dev/null | awk '{print $1}') || true
+    fi
+
+    for ip in $RESOLVED_IPS; do
+      [ -z "$ip" ] && continue
+      if [ -n "$port" ]; then
+        $SUDO nsenter -t "$PID" -n iptables -A OUTPUT -p tcp -d "$ip" --dport "$port" -j ACCEPT
+      else
+        $SUDO nsenter -t "$PID" -n iptables -A OUTPUT -p tcp -d "$ip" -j ACCEPT
+      fi
+      echo "[oci-hook] Bypass ACCEPT: $host ($ip)${port:+:$port}" >&2
+    done
+
+    IFS=','
+  done
+  IFS="$OLD_IFS"
 fi
 
 # Drop everything else (already default, but explicit for clarity)

--- a/container/oci-network-hook.sh
+++ b/container/oci-network-hook.sh
@@ -103,14 +103,13 @@ if [ -n "$GATEWAY_IP" ] && [ "$GATEWAY_IP" != "$HOST_IP" ]; then
   $SUDO nsenter -t "$PID" -n iptables -A OUTPUT -p tcp -d "$GATEWAY_IP" --dport "$SERVER_PORT" -j ACCEPT
 fi
 
-# Allow DNS to the slirp4netns DNS server (always gateway+1) and to HOST_IP/HCI_IP
-# (macOS Podman Machine also uses HOST_IP as a nameserver).
-# TCP:53 is needed for large DNS responses (e.g. MongoDB SRV records).
-if [ -n "$GATEWAY_IP" ]; then
-  GATEWAY_DNS="${GATEWAY_IP%.*}.$((${GATEWAY_IP##*.} + 1))"
-  $SUDO nsenter -t "$PID" -n iptables -A OUTPUT -p udp -d "$GATEWAY_DNS" --dport 53 -j ACCEPT
-  $SUDO nsenter -t "$PID" -n iptables -A OUTPUT -p tcp -d "$GATEWAY_DNS" --dport 53 -j ACCEPT
-fi
+# Allow DNS to the slirp4netns subnet (10.0.2.0/24) and to HOST_IP/HCI_IP.
+# slirp4netns configures the network AFTER createRuntime hooks fire, so the
+# gateway/DNS IPs are not yet in the routing table at hook time. Using the
+# subnet covers the DNS server (always 10.0.2.3 with default slirp4netns).
+# TCP:53 is required for large responses (e.g. MongoDB SRV records).
+$SUDO nsenter -t "$PID" -n iptables -A OUTPUT -p udp -d "10.0.2.0/24" --dport 53 -j ACCEPT
+$SUDO nsenter -t "$PID" -n iptables -A OUTPUT -p tcp -d "10.0.2.0/24" --dport 53 -j ACCEPT
 for dns_host in "$HOST_IP" "${HCI_IP:-}"; do
   [ -z "$dns_host" ] && continue
   $SUDO nsenter -t "$PID" -n iptables -A OUTPUT -p udp -d "$dns_host" --dport 53 -j ACCEPT

--- a/container/sandbox-run.sh
+++ b/container/sandbox-run.sh
@@ -94,10 +94,14 @@ GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-$GIT_AUTHOR_EMAIL}"
 SESSION_VOLUME="${SESSION_VOLUME:-task-session-${TASK_ID}}"
 podman volume exists "$SESSION_VOLUME" 2>/dev/null || podman volume create "$SESSION_VOLUME" >/dev/null
 
-# -- mise installs volume ------------------------------------------------------
+# -- mise installs bind mount --------------------------------------------------
 # Pre-populated at project settings save time (not at task launch).
-# MISE_VOLUME is set by the caller; defaults to mise-installs for single-project setups.
-MISE_VOLUME="${MISE_VOLUME:-mise-installs}"
+# MISE_INSTALL_PATH is a host directory bind-mounted :ro into the container.
+# If unset, no mise mount is added (runtimes unavailable but task still runs).
+MISE_MOUNT_FLAG=""
+if [ -n "${MISE_INSTALL_PATH:-}" ]; then
+  MISE_MOUNT_FLAG="-v ${MISE_INSTALL_PATH}:/usr/local/mise-installs:ro"
+fi
 
 # -- Shadow volumes (platform-specific build artifacts) ------------------------
 # SHADOW_DIRS is a space-separated list of workspace-relative dirs to shadow with
@@ -309,12 +313,14 @@ podman run --rm \
   -e GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-agent@sandbox}" \
   -e HOME=/home/agent \
   -e MISE_DATA_DIR=/home/agent/.local/share/mise \
+  -e CONTAINER_INIT_COMMANDS="${CONTAINER_INIT_COMMANDS:-}" \
+  -e BYPASS_HOSTS="${BYPASS_HOSTS:-}" \
   -v "$WORKTREE:/workspace:rw" \
   $SHADOW_MOUNTS \
   -v "$REPO_MOUNT" \
   --tmpfs /home/agent:rw,nosuid,nodev,size=256m,mode=777 \
   --mount "type=volume,src=${SESSION_VOLUME},dst=/home/agent/.claude:ro" \
-  --mount "type=volume,src=${MISE_VOLUME},dst=/home/agent/.local/share/mise/installs:ro" \
+  ${MISE_MOUNT_FLAG} \
   -v "$SETTINGS_TMP:/home/agent/.claude/settings.json:ro" \
   "$IMAGE" \
   -c "
@@ -341,14 +347,20 @@ podman run --rm \
     fi
 
     # Activate pre-installed runtimes. Binaries were installed into the
-    # mise-installs volume by the pre-start container. mise is not present here.
-    _bin_paths_file=/home/agent/.local/share/mise/installs/.bin-paths
+    # mise-installs dir on the host and bind-mounted :ro at /usr/local/mise-installs.
+    _bin_paths_file=/usr/local/mise-installs/.bin-paths
     if [ -s \"\$_bin_paths_file\" ]; then
-      export PATH=\"\$(cat \"\$_bin_paths_file\"):\$PATH\"
+      _paths=\$(sed 's|/home/agent/.local/share/mise/installs|/usr/local/mise-installs|g' \"\$_bin_paths_file\")
+      export PATH=\"\$_paths:\$PATH\"
     fi
-    _tool_env_file=/home/agent/.local/share/mise/installs/.tool-env
+    _tool_env_file=/usr/local/mise-installs/.tool-env
     if [ -s \"\$_tool_env_file\" ]; then
       . \"\$_tool_env_file\"
+    fi
+
+    if [ -n \"\${CONTAINER_INIT_COMMANDS:-}\" ]; then
+      # Output suppressed to keep logs clean — TODO: make verbose a project setting
+      eval \"\$CONTAINER_INIT_COMMANDS\" > /dev/null 2>&1 || true
     fi
 
     AGENT_BIN=\"\${AGENT_BINARY:-claude}\"

--- a/container/sandbox-run.sh
+++ b/container/sandbox-run.sh
@@ -5,7 +5,7 @@
 #
 # Modes: readonly, readwrite
 #
-# Mounts: worktree (/workspace), git dir (/repo.git) -- nothing else.
+# Mounts: worktree (/workspace), git dir (/tmp/repo.git) -- nothing else.
 # Session persistence via podman named volume (task-session-{task_id}).
 # Log capture via stdout pipe on host (tee).
 #
@@ -70,11 +70,11 @@ WORKTREE_NAME="$(basename "$WORKTREE")"
 # -- Mode-based access control ------------------------------------------------
 case "$MODE" in
   readonly)
-    REPO_MOUNT="$REPO_GIT:/repo.git:ro"
+    REPO_MOUNT="$REPO_GIT:/tmp/repo.git:ro"
     SANDBOX_MODE="readonly"
     ;;
   readwrite)
-    REPO_MOUNT="$REPO_GIT:/repo.git:rw"
+    REPO_MOUNT="$REPO_GIT:/tmp/repo.git:rw"
     SANDBOX_MODE="readwrite"
     ;;
   *)
@@ -118,8 +118,15 @@ done
 # -- Git worktree pointer ------------------------------------------------------
 # Write container-internal git pointers from the host before container starts,
 # so the container sees the correct paths without needing write access to them.
-echo "gitdir: /repo.git/worktrees/$WORKTREE_NAME" > "$WORKTREE/.git"
+echo "gitdir: /tmp/repo.git/worktrees/$WORKTREE_NAME" > "$WORKTREE/.git"
 echo "/workspace/.git" > "$REPO_GIT/worktrees/$WORKTREE_NAME/gitdir"
+
+# -- Progress helper ----------------------------------------------------------
+progress() {
+  if [ -n "${LOG_FILE:-}" ]; then
+    printf '{"type":"system","subtype":"progress","message":"%s"}\n' "$1" >> "$LOG_FILE"
+  fi
+}
 
 # -- Network policy -----------------------------------------------------------
 NETWORK_POLICY="${NETWORK_POLICY:-none}"
@@ -144,6 +151,8 @@ echo "Worktree: $WORKTREE" >&2
 echo "Network: $NETWORK_POLICY" >&2
 echo "Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)" >&2
 echo "Timeout: ${TIMEOUT}s" >&2
+echo "Memory: ${CONTAINER_MEMORY:-4g (default)}" >&2
+progress "Container memory limit: ${CONTAINER_MEMORY:-4g (default)}"
 echo "Args:$QUOTED_ARGS" >&2
 echo "=========================" >&2
 
@@ -151,13 +160,6 @@ echo "=========================" >&2
 podman_ver=$(podman version --format '{{.Client.Version}}' 2>/dev/null || echo "unknown")
 runtime_ver=$(podman info --format '{{.Host.OCIRuntime.Name}} {{.Host.OCIRuntime.Version}}' 2>/dev/null | head -1 || echo "unknown")
 echo "Podman: $podman_ver, Runtime: $runtime_ver" >&2
-
-# -- Progress helper ----------------------------------------------------------
-progress() {
-  if [ -n "${LOG_FILE:-}" ]; then
-    printf '{"type":"system","subtype":"progress","message":"%s"}\n' "$1" >> "$LOG_FILE"
-  fi
-}
 
 # -- Log capture setup ---------------------------------------------------------
 if [ -n "${LOG_FILE:-}" ]; then
@@ -283,9 +285,9 @@ podman run --rm \
   --read-only \
   --tmpfs /tmp:rw,nosuid,size=256m \
   --tmpfs /dev/shm:rw,nosuid,nodev,noexec,size=64m \
-  --memory 4g \
-  --pids-limit 512 \
-  --cpus 2 \
+  --memory "${CONTAINER_MEMORY:-4g}" \
+  --pids-limit "${CONTAINER_PIDS_LIMIT:-512}" \
+  --cpus "${CONTAINER_CPUS:-2}" \
   --ulimit core=0 \
   --timeout "$TIMEOUT" \
   -e ALLOWED_BRANCH="$ALLOWED_BRANCH" \

--- a/container/sandbox-run.sh
+++ b/container/sandbox-run.sh
@@ -305,16 +305,19 @@ podman run --rm \
   -e GIT_AUTHOR_EMAIL="${GIT_AUTHOR_EMAIL:-agent@sandbox}" \
   -e GIT_COMMITTER_NAME="${GIT_COMMITTER_NAME:-Sandbox Agent}" \
   -e GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-agent@sandbox}" \
+  -e HOME=/home/agent \
   -e MISE_DATA_DIR=/home/agent/.local/share/mise \
   -v "$WORKTREE:/workspace:rw" \
   $SHADOW_MOUNTS \
   -v "$REPO_MOUNT" \
   --tmpfs /home/agent:rw,nosuid,nodev,size=256m,mode=777 \
-  --mount "type=volume,src=${SESSION_VOLUME},dst=/home/agent/.claude" \
-  --mount "type=volume,src=${MISE_VOLUME},dst=/home/agent/.local/share/mise/installs" \
+  --mount "type=volume,src=${SESSION_VOLUME},dst=/home/agent/.claude:ro" \
+  --mount "type=volume,src=${MISE_VOLUME},dst=/home/agent/.local/share/mise/installs:ro" \
   -v "$SETTINGS_TMP:/home/agent/.claude/settings.json:ro" \
   "$IMAGE" \
   -c "
+    export HOME=/home/agent
+
     # Progress helper (JSON to stdout -> tee -> LOG_FILE)
     _progress() { printf '{\"type\":\"system\",\"subtype\":\"progress\",\"message\":\"%s\"}\\n' \"\$1\"; }
 
@@ -328,9 +331,6 @@ podman run --rm \
     if [ -n \"\${AGENT_INIT_SCRIPT:-}\" ]; then
       eval \"\$AGENT_INIT_SCRIPT\"
     else
-      if [ ! -f /home/agent/.claude/settings.json ] && [ -f /etc/claude-defaults/settings.json ]; then
-        cp /etc/claude-defaults/settings.json /home/agent/.claude/settings.json
-      fi
       if [ -f /home/agent/.claude.json ]; then
         jq '.hasCompletedOnboarding = true | .projects[\\\"/workspace\\\"].hasTrustDialogAccepted = true' /home/agent/.claude.json > /tmp/cj.json 2>/dev/null && cp /tmp/cj.json /home/agent/.claude.json && rm -f /tmp/cj.json
       else

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -21,6 +21,7 @@ ysa run <prompt> [options]
 | `-v, --verbose` | boolean | — | Show full output including tool calls |
 | `-i, --interactive` | boolean | — | Attach a live terminal session inside the sandbox |
 | `--no-commit` | boolean | — | Prevent the agent from committing to git |
+| `--provider <provider>` | `claude\|deepseek\|mistral` | `claude` | LLM provider to use |
 
 ## Examples
 

--- a/docs/guides/network.md
+++ b/docs/guides/network.md
@@ -70,6 +70,22 @@ await runTask({
 
 A scoped rule allows **all HTTP methods** (GET, POST, PUT, etc.) for requests whose host matches and whose path starts with `pathPrefix`. Everything else still goes through the default strict policy.
 
+## Bypass hosts
+
+For services that don't speak HTTP/HTTPS (e.g. MongoDB, Redis, raw TCP), use `bypassHosts` to open a direct iptables `ACCEPT` rule that skips the proxy entirely:
+
+```ts
+await runTask({
+  ...
+  networkPolicy: "strict",
+  bypassHosts: ["cluster.mongodb.net", "my-db.redis.cloud:6380"],
+});
+```
+
+Entries can be `host` (all TCP ports) or `host:port`. DNS is resolved at container start time (including SRV chains for MongoDB clusters).
+
+Provider adapters can also declare `bypassHosts` to allow their API endpoint through unconditionally — see `src/providers/deepseek.ts` as an example.
+
 ## none (default)
 
 The container has no outbound network access at all — no proxy is started and the OCI network hooks block all outbound connections. Use this for pure code generation tasks.
@@ -78,3 +94,4 @@ The container has no outbound network access at all — no proxy is started and 
 
 - [`ysa run --network`](/cli/run) — set the policy from the CLI
 - [RunConfig.proxyRules](/api/run-task#runconfig-fields) — per-task scoped allow rules
+- [RunConfig.bypassHosts](/api/run-task#runconfig-fields) — direct TCP bypass (skips proxy)

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -1,44 +1,82 @@
 # Providers
 
-ysa supports multiple AI providers. Claude is the default; Mistral is also built in.
+ysa supports multiple AI providers. Claude is the default.
 
 ## Built-in providers
 
 ### Claude
 
 ```bash
-ysa run "add tests" --provider claude  # (default, --provider flag not yet in CLI)
+ysa run "add tests"                          # defaults to Claude
+ysa run "add tests" --provider claude
 ```
 
-Auth: Set `CLAUDE_CODE_OAUTH_TOKEN` in your environment, or log in with `claude` CLI before running ysa.
+Auth: Log in with the `claude` CLI before running ysa (`claude login`). The OAuth token is picked up automatically.
 
 Default model: `claude-sonnet-4-6`
 
+### DeepSeek
+
+```bash
+ysa run "add tests" --provider deepseek
+```
+
+Auth: Store your API key with:
+
+```bash
+ysa key set deepseek
+```
+
+DeepSeek uses Claude Code's API protocol (`api.deepseek.com/anthropic`) so the same agent binary works without modification.
+
+Default model: `deepseek-v4-pro` (sub-agent tasks use `deepseek-v4-flash`)
+
 ### Mistral
 
-Auth: Set `MISTRAL_API_KEY` in your environment.
+```bash
+ysa run "add tests" --provider mistral
+```
+
+Auth: Store your API key with:
+
+```bash
+ysa key set mistral
+```
 
 Default model: `devstral-small-latest`
+
+## Managing API keys
+
+```bash
+ysa key set <provider>     # prompt for key and store it securely
+ysa key check <provider>   # verify a key is stored
+ysa key delete <provider>  # remove a stored key
+```
 
 ## Switching providers via API
 
 ```ts
 await runTask({
   ...
-  provider: "mistral",
-  model: "devstral-small-latest",
+  provider: "deepseek",
 });
 ```
-
-## Switching providers via CLI
-
-The CLI currently defaults to Claude. To use Mistral, use the API directly or set `default_model` in the ysa config database.
 
 ## Custom providers
 
 See [Providers API reference](/api/providers) for how to implement and register a custom `ProviderAdapter`.
 
+If your provider's API endpoint requires direct TCP access (bypassing the proxy), set `bypassHosts` on the adapter:
+
+```ts
+export const myAdapter: ProviderAdapter = {
+  ...
+  bypassHosts: ["api.myprovider.com"],
+};
+```
+
 ## Related
 
 - [Providers API](/api/providers) — `ProviderAdapter` interface and `registerProvider`
 - [RunConfig.provider](/api/run-task#runconfig-fields) — per-task provider selection
+- [`ysa run --provider`](/cli/run) — CLI flag

--- a/src/cli/commands/key.ts
+++ b/src/cli/commands/key.ts
@@ -1,0 +1,57 @@
+import { createInterface } from "readline";
+import { setApiKey, deleteApiKey, getApiKey } from "../keystore";
+
+async function readSecret(prompt: string): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    process.stdout.write(prompt);
+    const origWrite = (rl as any).output.write.bind((rl as any).output);
+    (rl as any).output.write = () => true;
+    rl.once("line", (line) => {
+      (rl as any).output.write = origWrite;
+      process.stdout.write("\n");
+      rl.close();
+      resolve(line.trim());
+    });
+  });
+}
+
+export async function keyCommand(action: string, provider: string | undefined) {
+  if (!provider) {
+    console.error("Usage: ysa key set <provider>");
+    console.error("       ysa key delete <provider>");
+    console.error("       ysa key check <provider>");
+    process.exit(1);
+  }
+
+  switch (action) {
+    case "set": {
+      const key = await readSecret(`Enter API key for ${provider}: `);
+      if (!key) {
+        console.error("No key entered.");
+        process.exit(1);
+      }
+      await setApiKey(provider, key);
+      console.log(`API key stored for ${provider}`);
+      break;
+    }
+    case "delete": {
+      await deleteApiKey(provider);
+      console.log(`API key deleted for ${provider}`);
+      break;
+    }
+    case "check": {
+      const stored = await getApiKey(provider);
+      if (stored) {
+        console.log(`API key for ${provider} is configured (${stored.slice(0, 8)}...)`);
+      } else {
+        console.log(`No API key configured for ${provider}`);
+        process.exit(1);
+      }
+      break;
+    }
+    default:
+      console.error(`Unknown action: ${action}. Use set, delete, or check.`);
+      process.exit(1);
+  }
+}

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -52,12 +52,14 @@ export async function runCommand(
     verbose?: boolean;
     interactive?: boolean;
     allowCommit?: boolean;
+    provider?: string;
   },
 ) {
   const projectRoot = await resolveProjectRoot(opts.project);
   const taskId = crypto.randomUUID();
   const worktreePrefix = join(projectRoot, ".ysa", "worktrees/");
   const worktreePath = `${worktreePrefix}${taskId}`;
+  const provider = opts.provider ?? "claude";
 
   if (opts.interactive) {
     await runInteractive({
@@ -66,7 +68,7 @@ export async function runCommand(
       branch: opts.branch,
       projectRoot,
       worktreePrefix,
-      provider: "claude",
+      provider,
       networkPolicy: opts.network as "none" | "strict" | "custom",
     });
     return;
@@ -78,7 +80,7 @@ export async function runCommand(
     branch: opts.branch,
     projectRoot,
     worktreePrefix,
-    provider: "claude",
+    provider,
     maxTurns: parseInt(opts.maxTurns),
     allowedTools: opts.tools?.split(","),
     networkPolicy: opts.network as "none" | "strict" | "custom",
@@ -137,7 +139,7 @@ export async function runCommand(
         branch: opts.branch,
         projectRoot,
         worktreePrefix,
-        provider: "claude",
+        provider,
         maxTurns: parseInt(opts.maxTurns),
         networkPolicy: opts.network as "none" | "strict" | "custom",
         resumeSessionId: currentSessionId,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import { teardownCommand } from "./commands/teardown";
 import { refineCommand } from "./commands/refine";
 import { setupCommand } from "./commands/setup";
 import { runtimeCommand } from "./commands/runtime";
+import { keyCommand } from "./commands/key";
 
 const program = new Command();
 
@@ -34,6 +35,7 @@ program
   .option("-v, --verbose", "Show full log including tool calls")
   .option("-i, --interactive", "Attach stdin/stdout for a live terminal session inside the sandbox")
   .option("--no-commit", "Prevent the agent from committing to git (analysis/review tasks)")
+  .option("--provider <provider>", "LLM provider: claude|deepseek|mistral", "claude")
   .action((prompt: string, opts: Record<string, string | boolean>) => {
     runCommand(prompt, {
       branch: opts.branch as string,
@@ -45,6 +47,7 @@ program
       verbose: opts.verbose as boolean | undefined,
       interactive: opts.interactive === true,
       allowCommit: opts.commit !== false,
+      provider: opts.provider as string | undefined,
     });
   });
 
@@ -116,6 +119,15 @@ program
   .description("First-run setup: preflight checks, image build, CA cert, network hooks")
   .action(() => {
     setupCommand();
+  });
+
+program
+  .command("key")
+  .description("Manage provider API keys")
+  .argument("<action>", "set | delete | check")
+  .argument("<provider>", "Provider name, e.g. deepseek or mistral")
+  .action((action: string, provider: string) => {
+    keyCommand(action, provider);
   });
 
 program.parse();

--- a/src/cli/ysa-config.ts
+++ b/src/cli/ysa-config.ts
@@ -4,8 +4,9 @@ import { existsSync } from "fs";
 
 export interface YsaConfig {
   sandbox?: {
-    runtimes?: string[];  // mise tools, e.g. ["node@22", "python@3.12"]
-    packages?: string[];  // apt packages, e.g. ["libpq-dev", "imagemagick"]
+    runtimes?: string[];        // mise tools, e.g. ["node@22", "python@3.12"]
+    packages?: string[];        // apt/apk packages, e.g. ["libpq-dev", "chromium"]
+    global_packages?: string[]; // global installs, e.g. ["bun:@playwright/cli", "pip:playwright"]
   };
 }
 
@@ -33,6 +34,7 @@ function parseToml(content: string): YsaConfig {
     if (!config.sandbox) config.sandbox = {};
     if (key === "runtimes") config.sandbox.runtimes = items;
     if (key === "packages") config.sandbox.packages = items;
+    if (key === "global_packages") config.sandbox.global_packages = items;
   }
 
   return config;
@@ -43,6 +45,7 @@ function serializeToml(config: YsaConfig): string {
   const arr = (items: string[]) => `[${items.map((i) => `"${i}"`).join(", ")}]`;
   if (config.sandbox?.runtimes?.length) lines.push(`runtimes = ${arr(config.sandbox.runtimes)}`);
   if (config.sandbox?.packages?.length) lines.push(`packages = ${arr(config.sandbox.packages)}`);
+  if (config.sandbox?.global_packages?.length) lines.push(`global_packages = ${arr(config.sandbox.global_packages)}`);
   return lines.join("\n") + "\n";
 }
 

--- a/src/cli/ysa-config.ts
+++ b/src/cli/ysa-config.ts
@@ -7,6 +7,7 @@ export interface YsaConfig {
     runtimes?: string[];        // mise tools, e.g. ["node@22", "python@3.12"]
     packages?: string[];        // apt/apk packages, e.g. ["libpq-dev", "chromium"]
     global_packages?: string[]; // global installs, e.g. ["bun:@playwright/cli", "pip:playwright"]
+    init_commands?: string[];   // commands run inside container before agent starts, e.g. ["redis-server --daemonize yes"]
   };
 }
 
@@ -35,6 +36,7 @@ function parseToml(content: string): YsaConfig {
     if (key === "runtimes") config.sandbox.runtimes = items;
     if (key === "packages") config.sandbox.packages = items;
     if (key === "global_packages") config.sandbox.global_packages = items;
+    if (key === "init_commands") config.sandbox.init_commands = items;
   }
 
   return config;
@@ -46,6 +48,7 @@ function serializeToml(config: YsaConfig): string {
   if (config.sandbox?.runtimes?.length) lines.push(`runtimes = ${arr(config.sandbox.runtimes)}`);
   if (config.sandbox?.packages?.length) lines.push(`packages = ${arr(config.sandbox.packages)}`);
   if (config.sandbox?.global_packages?.length) lines.push(`global_packages = ${arr(config.sandbox.global_packages)}`);
+  if (config.sandbox?.init_commands?.length) lines.push(`init_commands = ${arr(config.sandbox.init_commands)}`);
   return lines.join("\n") + "\n";
 }
 

--- a/src/providers/deepseek.ts
+++ b/src/providers/deepseek.ts
@@ -1,0 +1,41 @@
+import { claudeAdapter } from "./claude";
+import type { ProviderAdapter, ProviderModel, ContainerConfig } from "./types";
+
+const DEEPSEEK_BASE_URL = "https://api.deepseek.com/anthropic";
+
+const DEEPSEEK_MODELS: ProviderModel[] = [
+  { id: "deepseek-v4-pro",   name: "DeepSeek V4 Pro",   isDefault: true },
+  { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash",  isDefault: false },
+];
+
+async function getDeepSeekAuthEnv(): Promise<Record<string, string>> {
+  const { getApiKey } = await import("../cli/keystore");
+  const apiKey = await getApiKey("deepseek");
+  if (!apiKey) {
+    throw new Error("DeepSeek API key not configured. Run: ysa key set deepseek <key>");
+  }
+  return {
+    ANTHROPIC_AUTH_TOKEN: apiKey,
+    ANTHROPIC_BASE_URL: DEEPSEEK_BASE_URL,
+  };
+}
+
+const DEEPSEEK_INIT_SCRIPT = claudeAdapter.initContainerConfig().initScript + `
+export ANTHROPIC_MODEL=deepseek-v4-pro
+export ANTHROPIC_DEFAULT_OPUS_MODEL=deepseek-v4-pro
+export ANTHROPIC_DEFAULT_SONNET_MODEL=deepseek-v4-pro
+export ANTHROPIC_DEFAULT_HAIKU_MODEL=deepseek-v4-flash
+export CLAUDE_CODE_SUBAGENT_MODEL=deepseek-v4-flash`;
+
+export const deepseekAdapter: ProviderAdapter = {
+  ...claudeAdapter,
+  id: "deepseek",
+  name: "DeepSeek",
+  models: DEEPSEEK_MODELS,
+  authEnvKeys: ["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL"],
+  getAuthEnv: getDeepSeekAuthEnv,
+  bypassHosts: ["api.deepseek.com"],
+  initContainerConfig(_opts?: { model?: string }): ContainerConfig {
+    return { initScript: DEEPSEEK_INIT_SCRIPT, envVars: {} };
+  },
+};

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1,10 +1,12 @@
 import type { ProviderAdapter } from "./types";
 import { claudeAdapter } from "./claude";
 import { mistralAdapter } from "./mistral";
+import { deepseekAdapter } from "./deepseek";
 
 const registry = new Map<string, ProviderAdapter>([
   ["claude", claudeAdapter],
   ["mistral", mistralAdapter],
+  ["deepseek", deepseekAdapter],
 ]);
 
 export function getProvider(id: string): ProviderAdapter {

--- a/src/runtime/container.ts
+++ b/src/runtime/container.ts
@@ -1,6 +1,6 @@
 import { readFile, stat } from "fs/promises";
 import { existsSync } from "fs";
-import { resolve } from "path";
+import { resolve, basename } from "path";
 import { getProvider } from "../providers";
 
 async function fileExists(path: string): Promise<boolean> {
@@ -83,7 +83,7 @@ function globalInstallCmd(manager: string, pkgs: string[]): string {
     case "gem":    return `gem install --no-document ${list}`;
     case "cargo":  return `cargo install ${list} && rm -rf /root/.cargo/registry`;
     case "go":     return `go install ${list} && go clean -cache`;
-    default:       return `bun add -g ${list} && rm -rf /usr/local/.bun-cache`;
+    default:       return `bun add -g ${list} && rm -rf /usr/local/.bun-cache /home/agent/.bun /tmp/bun*`;
   }
 }
 
@@ -247,13 +247,13 @@ export async function buildBaseImages(caDir: string, onLog?: (line: string) => v
   return buildProxyImage(caDir, onLog);
 }
 
-// Install language runtimes into a named mise-installs volume via a short-lived
+// Install language runtimes into a host-side bind-mount directory via a short-lived
 // container. Runs WITHOUT --tmpfs /home/agent so the image's mise binary is
 // accessible from the image layer. Writes resolved bin paths to .bin-paths
-// inside the volume so task containers can activate tools without touching mise.
+// inside the dir so task containers can activate tools without touching mise.
 export async function installRuntimes(
   tools: string[],
-  installsVolume: string,
+  installsPath: string,
   image: string = "sandbox-claude",
   extraEnv: Record<string, string> = {},
   runtimeEnv: Record<string, string> = {},
@@ -262,15 +262,15 @@ export async function installRuntimes(
 ): Promise<{ ok: boolean; error?: string }> {
   if (tools.length === 0) return { ok: true };
 
-  const dataVolume = installsVolume.replace(/^mise-installs/, "mise-data");
+  const dataVolume = `mise-data-${basename(installsPath)}`;
 
-  await runShell(`podman volume exists ${installsVolume} 2>/dev/null || podman volume create ${installsVolume}`);
+  await runShell(`mkdir -p "${installsPath}"`);
   await runShell(`podman volume exists ${dataVolume} 2>/dev/null || podman volume create ${dataVolume}`);
 
   const toolEnvLines = Object.entries(runtimeEnv).map(([k, v]) => `export ${k}=${v}`);
   const totalSteps = tools.length + 1; // +1 for finalize step
   const installSteps = tools.map((tool, i) =>
-    `echo "STEP ${i + 1}/${totalSteps}: Installing ${tool}" && "$MISE" use --global "${tool}" --yes 2>/dev/null || true`
+    `echo "STEP ${i + 1}/${totalSteps}: Installing ${tool}" && "$MISE" use --global "${tool}" --yes`
   );
   const script = [
     'MISE=/home/agent/.local/bin/mise',
@@ -295,11 +295,12 @@ export async function installRuntimes(
     "--network", "slirp4netns",
     "--cap-drop", "ALL",
     "--security-opt", "no-new-privileges",
+    "-e", "HOME=/home/agent",
     "-e", "MISE_DATA_DIR=/home/agent/.local/share/mise",
     "-e", `MISE_TOOLS=${tools.join(" ")}`,
     ...Object.entries(extraEnv).flatMap(([k, v]) => ["-e", `${k}=${v}`]),
     "--mount", `type=volume,src=${dataVolume},dst=/home/agent/.local/share/mise`,
-    "--mount", `type=volume,src=${installsVolume},dst=/home/agent/.local/share/mise/installs`,
+    "-v", `${installsPath}:/home/agent/.local/share/mise/installs`,
     image,
     "-c", script,
   ], { stdout: "pipe", stderr: "pipe" });
@@ -323,15 +324,15 @@ export async function installDepsInShadow(opts: {
   shadowVolume: string;
   shadowDir: string;         // workspace-relative dir, e.g. "node_modules"
   image?: string;
-  miseVolume?: string;
-  binPathsFile?: string;     // path inside miseVolume to .bin-paths
+  miseInstallsPath?: string;
+  binPathsFile?: string;     // path inside miseInstallsPath to .bin-paths
 }): Promise<{ ok: boolean; error?: string }> {
   const image = opts.image ?? "sandbox-claude";
   const binPathsFile = opts.binPathsFile ?? "/home/agent/.local/share/mise/installs/.bin-paths";
 
   await runShell(`podman volume exists ${opts.shadowVolume} 2>/dev/null || podman volume create ${opts.shadowVolume}`);
 
-  const activateMise = opts.miseVolume
+  const activateMise = opts.miseInstallsPath
     ? `if [ -s ${binPathsFile} ]; then export PATH="$(cat ${binPathsFile}):$PATH"; fi`
     : "";
 
@@ -350,8 +351,8 @@ export async function installDepsInShadow(opts: {
     "--mount", `type=volume,src=${opts.shadowVolume},dst=/workspace/${opts.shadowDir}`,
   ];
 
-  if (opts.miseVolume) {
-    args.push("--mount", `type=volume,src=${opts.miseVolume},dst=/home/agent/.local/share/mise/installs`);
+  if (opts.miseInstallsPath) {
+    args.push("-v", `${opts.miseInstallsPath}:/home/agent/.local/share/mise/installs:ro`);
   }
 
   args.push(image, "-c", script);
@@ -389,7 +390,7 @@ export interface SpawnSandboxOpts {
   extraLabels?: Record<string, string>; // extra podman labels added to the container (caller-defined, for filtering)
   shadowDirs?: string[];      // forwarded as SHADOW_DIRS env var to sandbox-run.sh
   depCacheVolume?: string;    // pre-populated dep cache volume to use for the first shadow dir
-  miseVolume?: string;        // name of the pre-populated mise-installs volume to mount
+  miseInstallsPath?: string;  // host path to pre-populated mise-installs dir (bind-mounted :ro)
   interactive?: boolean;      // attach stdin/tty for direct terminal use
   containerMemory?: string;   // e.g. "8g" — overrides sandbox-run.sh default of 4g
   containerCpus?: number;     // e.g. 4 — overrides sandbox-run.sh default of 2
@@ -407,7 +408,7 @@ export async function spawnSandbox(opts: SpawnSandboxOpts) {
   if (opts.extraPodEnv) env.EXTRA_POD_ENV = opts.extraPodEnv;
   if (opts.shadowDirs && opts.shadowDirs.length > 0) env.SHADOW_DIRS = opts.shadowDirs.join(" ");
   if (opts.depCacheVolume) env.DEP_CACHE_VOLUME = opts.depCacheVolume;
-  if (opts.miseVolume) env.MISE_VOLUME = opts.miseVolume;
+  if (opts.miseInstallsPath) env.MISE_INSTALL_PATH = opts.miseInstallsPath;
   if (opts.interactive) env.INTERACTIVE = "1";
   if (opts.extraLabels) env.EXTRA_LABELS = Object.entries(opts.extraLabels).map(([k, v]) => `${k}=${v}`).join(" ");
   if (opts.containerMemory) env.CONTAINER_MEMORY = opts.containerMemory;

--- a/src/runtime/container.ts
+++ b/src/runtime/container.ts
@@ -39,6 +39,10 @@ export function setContainerDir(dir: string): void {
   CONTAINER_DIR = dir;
 }
 
+export function getContainerDir(): string {
+  return CONTAINER_DIR;
+}
+
 export async function getSeccompProfile(): Promise<string> {
   return resolve(_containerDir, "seccomp.json");
 }
@@ -98,6 +102,9 @@ export async function buildProjectImage(
       ? `apt-get update && apt-get install -y --no-install-recommends ${packages.join(" ")} && rm -rf /var/lib/apt/lists/*`
       : `apk add --no-cache ${packages.join(" ")}`;
     lines.push(`RUN ${installCmd}`);
+    if (packageManager === "apt") {
+      lines.push(`RUN awk -F: 'BEGIN{OFS=":"} !($1!="root" && $6=="/")' /etc/passwd > /tmp/passwd.tmp && mv /tmp/passwd.tmp /etc/passwd`);
+    }
   }
 
   const byManager = new Map<string, string[]>();
@@ -148,6 +155,17 @@ export async function getImagePackagesHash(image: string): Promise<string | null
   return val || null;
 }
 
+export async function getImageCfHash(image: string): Promise<string | null> {
+  const proc = Bun.spawn(
+    ["podman", "image", "inspect", image, "--format", "{{index .Labels \"ysa.cf-hash\"}}"],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const stdout = await new Response(proc.stdout).text();
+  await proc.exited;
+  const val = stdout.trim();
+  return val || null;
+}
+
 export interface RebuildSandboxImageOpts {
   apkPackages?: string[];
   image?: string;
@@ -172,9 +190,12 @@ export async function rebuildSandboxImage(opts: RebuildSandboxImageOpts): Promis
 
   const extraPackages = apkPackages.join(" ");
   const packagesHash = Bun.hash([...apkPackages].sort().join(",")).toString(16);
+  const cfContent = await Bun.file(resolve(CONTAINER_DIR, "Containerfile")).text();
+  const cfHash = Bun.hash(cfContent).toString(16);
   const proc = Bun.spawn([
     "podman", "build", "-t", image,
     "--label", `ysa.packages=${packagesHash}`,
+    "--label", `ysa.cf-hash=${cfHash}`,
     "--build-arg", `EXTRA_PACKAGES=${extraPackages}`,
     "--build-arg", `AGENT=${agent}`,
     "-f", `${CONTAINER_DIR}/Containerfile`,
@@ -370,6 +391,9 @@ export interface SpawnSandboxOpts {
   depCacheVolume?: string;    // pre-populated dep cache volume to use for the first shadow dir
   miseVolume?: string;        // name of the pre-populated mise-installs volume to mount
   interactive?: boolean;      // attach stdin/tty for direct terminal use
+  containerMemory?: string;   // e.g. "8g" — overrides sandbox-run.sh default of 4g
+  containerCpus?: number;     // e.g. 4 — overrides sandbox-run.sh default of 2
+  containerPidsLimit?: number; // e.g. 1024 — overrides sandbox-run.sh default of 512
 }
 
 export async function spawnSandbox(opts: SpawnSandboxOpts) {
@@ -386,6 +410,9 @@ export async function spawnSandbox(opts: SpawnSandboxOpts) {
   if (opts.miseVolume) env.MISE_VOLUME = opts.miseVolume;
   if (opts.interactive) env.INTERACTIVE = "1";
   if (opts.extraLabels) env.EXTRA_LABELS = Object.entries(opts.extraLabels).map(([k, v]) => `${k}=${v}`).join(" ");
+  if (opts.containerMemory) env.CONTAINER_MEMORY = opts.containerMemory;
+  if (opts.containerCpus !== undefined) env.CONTAINER_CPUS = String(opts.containerCpus);
+  if (opts.containerPidsLimit !== undefined) env.CONTAINER_PIDS_LIMIT = String(opts.containerPidsLimit);
 
   return Bun.spawn(
     [

--- a/src/runtime/container.ts
+++ b/src/runtime/container.ts
@@ -71,25 +71,56 @@ export function projectImageName(projectRoot: string, provider: string): string 
 
 // Build a project-specific image by layering packages on top of the provider's base image.
 // Much faster than a full Containerfile build — only adds one layer.
+function globalInstallCmd(manager: string, pkgs: string[]): string {
+  const list = pkgs.join(" ");
+  switch (manager) {
+    case "pip":    return `pip install --no-cache-dir --break-system-packages ${list} && rm -rf /root/.cache/pip`;
+    case "npm":    return `npm install -g ${list} && npm cache clean --force`;
+    case "gem":    return `gem install --no-document ${list}`;
+    case "cargo":  return `cargo install ${list} && rm -rf /root/.cargo/registry`;
+    case "go":     return `go install ${list} && go clean -cache`;
+    default:       return `bun add -g ${list} && rm -rf /usr/local/.bun-cache`;
+  }
+}
+
 export async function buildProjectImage(
   packages: string[],
   targetImage: string,
   fromImage: string,
   packageManager: "apt" | "apk",
+  globalPackages: string[] = [],
   onLog?: (line: string) => void,
 ): Promise<{ ok: boolean; error?: string }> {
-  const installCmd = packageManager === "apt"
-    ? `apt-get update && apt-get install -y --no-install-recommends ${packages.join(" ")} && rm -rf /var/lib/apt/lists/*`
-    : `apk add --no-cache ${packages.join(" ")}`;
+  const lines = [`FROM ${fromImage}`, "USER root"];
 
-  const dockerfile = [
-    `FROM ${fromImage}`,
-    "USER root",
-    `RUN ${installCmd}`,
-    "USER agent",
-  ].join("\n");
+  if (packages.length > 0) {
+    const installCmd = packageManager === "apt"
+      ? `apt-get update && apt-get install -y --no-install-recommends ${packages.join(" ")} && rm -rf /var/lib/apt/lists/*`
+      : `apk add --no-cache ${packages.join(" ")}`;
+    lines.push(`RUN ${installCmd}`);
+  }
 
-  const packagesHash = Bun.hash([...packages].sort().join(",")).toString(16);
+  const byManager = new Map<string, string[]>();
+  for (const entry of globalPackages) {
+    const sep = entry.indexOf(":");
+    if (sep === -1) continue;
+    const manager = entry.slice(0, sep);
+    const pkg = entry.slice(sep + 1);
+    const list = byManager.get(manager) ?? [];
+    list.push(pkg);
+    byManager.set(manager, list);
+  }
+  for (const [manager, pkgs] of byManager) {
+    lines.push(`RUN ${globalInstallCmd(manager, pkgs)}`);
+  }
+
+  lines.push("USER agent");
+  const dockerfile = lines.join("\n");
+
+  const hashInput = globalPackages.length > 0
+    ? [...packages].sort().join(",") + "|" + [...globalPackages].sort().join(",")
+    : [...packages].sort().join(",");
+  const packagesHash = Bun.hash(hashInput).toString(16);
   const proc = Bun.spawn(
     ["podman", "build", "-t", targetImage, "--label", `ysa.packages=${packagesHash}`, "-f", "-", "."],
     { stdin: new TextEncoder().encode(dockerfile), stdout: "pipe", stderr: "pipe" },

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -3,7 +3,7 @@ export type { RunOptions } from "./runner";
 export { runInteractive } from "./interactive";
 export { getAuthEnv } from "./auth";
 export { createWorktree, removeWorktree, prepareWorktree } from "./worktree";
-export { spawnSandbox, stopContainer, teardownContainer, getSeccompProfile, setContainerDir, rebuildSandboxImage, buildProjectImage, buildProxyImage, buildBaseImages, installRuntimes, installDepsInShadow, projectImageName } from "./container";
+export { spawnSandbox, stopContainer, teardownContainer, getSeccompProfile, setContainerDir, getContainerDir, rebuildSandboxImage, buildProjectImage, buildProxyImage, buildBaseImages, installRuntimes, installDepsInShadow, projectImageName, getImagePackagesHash, getImageCfHash } from "./container";
 export type { SpawnSandboxOpts, RebuildSandboxImageOpts } from "./container";
 export { ensureProxy, stopProxy } from "./proxy";
 export type { ScopedAllowRule } from "./proxy";

--- a/src/runtime/mise.ts
+++ b/src/runtime/mise.ts
@@ -1,5 +1,6 @@
-import { stat } from "fs/promises";
+import { stat, readFile } from "fs/promises";
 import { join } from "path";
+import { homedir } from "os";
 
 async function fileExists(path: string): Promise<boolean> {
   try {
@@ -20,25 +21,27 @@ async function runShell(cmd: string): Promise<{ ok: boolean; stdout: string; std
   return { ok: exitCode === 0, stdout: stdout.trim(), stderr: stderr.trim() };
 }
 
-function volumeNameForProject(projectRoot: string): string {
+function installsPathForProject(projectRoot: string): string {
   const hash = Bun.hash(projectRoot).toString(16).slice(0, 8);
-  return `mise-installs-${hash}`;
+  return join(homedir(), ".cache", "ysa-agent", "mise-installs", hash);
 }
 
 function hashTools(tools: string[]): string {
   return Bun.hash([...tools].sort().join(",")).toString(16);
 }
 
-async function getVolumeToolsHash(volume: string): Promise<string | null> {
-  const { ok, stdout } = await runShell(
-    `podman volume inspect ${volume} --format '{{index .Labels "ysa.tools-hash"}}' 2>/dev/null`,
-  );
-  return ok && stdout.trim() ? stdout.trim() : null;
+async function getToolsHash(installsPath: string): Promise<string | null> {
+  try {
+    const content = await readFile(join(installsPath, ".tools-hash"), "utf-8");
+    return content.trim() || null;
+  } catch {
+    return null;
+  }
 }
 
 // Ensure mise runtimes are pre-installed for the project.
-// Returns the mise-installs volume name if tools were found/installed, undefined otherwise.
-// Fast path: if the volume already has a matching tools hash, returns immediately.
+// Returns the mise-installs host path if tools were found/installed, undefined otherwise.
+// Fast path: if the installs dir already has a matching tools hash, returns immediately.
 // toolsOverride: explicit list from .ysa.toml — takes precedence over file detection.
 export async function ensureMiseRuntimes(
   projectRoot: string,
@@ -54,25 +57,20 @@ export async function ensureMiseRuntimes(
     const hasMiseToml = await fileExists(join(projectRoot, ".mise.toml"));
     const hasToolVersions = await fileExists(join(projectRoot, ".tool-versions"));
     if (!hasMiseToml && !hasToolVersions) return undefined;
-    // Tools will be read from project files by mise itself inside the container
-    tools = ["__auto__"]; // sentinel meaning: use mise's own file detection
+    tools = ["__auto__"];
   }
 
-  const installsVolume = volumeNameForProject(projectRoot);
-  const dataVolume = installsVolume.replace("mise-installs", "mise-data");
+  const installsPath = installsPathForProject(projectRoot);
+  const hash = installsPath.split("/").pop() ?? "mise";
+  const dataVolume = `mise-data-${hash}`;
   const targetHash = hashTools(tools);
 
-  if (await getVolumeToolsHash(installsVolume) === targetHash) return installsVolume;
+  if (await getToolsHash(installsPath) === targetHash) return installsPath;
 
   onProgress?.("Installing runtimes via mise...");
 
-  // Recreate installs volume with updated label so the hash persists cross-platform
-  // (podman volume mountpoints are inside the VM on macOS, not accessible from host)
-  await runShell(`podman volume rm ${installsVolume} 2>/dev/null || true`);
-  await runShell(`podman volume create --label ysa.tools-hash=${targetHash} ${installsVolume}`);
-  await runShell(
-    `podman volume exists ${dataVolume} 2>/dev/null || podman volume create ${dataVolume}`,
-  );
+  await runShell(`rm -rf "${installsPath}" && mkdir -p "${installsPath}"`);
+  await runShell(`podman volume exists ${dataVolume} 2>/dev/null || podman volume create ${dataVolume}`);
 
   const isAuto = tools[0] === "__auto__";
   const installCmd = isAuto
@@ -92,9 +90,10 @@ export async function ensureMiseRuntimes(
     "--network", "slirp4netns",
     "--cap-drop", "ALL",
     "--security-opt", "no-new-privileges",
+    "-e", "HOME=/home/agent",
     "-e", "MISE_DATA_DIR=/home/agent/.local/share/mise",
     "--mount", `type=volume,src=${dataVolume},dst=/home/agent/.local/share/mise`,
-    "--mount", `type=volume,src=${installsVolume},dst=/home/agent/.local/share/mise/installs`,
+    "-v", `${installsPath}:/home/agent/.local/share/mise/installs`,
   ];
 
   if (isAuto) {
@@ -106,8 +105,8 @@ export async function ensureMiseRuntimes(
   const proc = Bun.spawn(runArgs, { stdout: "pipe", stderr: "pipe" });
   await proc.exited;
 
-  // Non-fatal: task runs without pre-loaded runtimes if install fails
   if (proc.exitCode !== 0) return undefined;
 
-  return installsVolume;
+  await Bun.write(join(installsPath, ".tools-hash"), targetHash);
+  return installsPath;
 }

--- a/src/runtime/runner.ts
+++ b/src/runtime/runner.ts
@@ -209,12 +209,13 @@ export async function runTask(config: RunConfig, opts?: RunOptions): Promise<Tas
   // 8. Proxy auto-start
   if (config.networkPolicy === "strict") {
     emitProgress("Starting network proxy...");
-    await ensureProxy(config.proxyRules, adapter.bypassHosts, config.serverPort);
+    const allBypassHosts = [...(adapter.bypassHosts ?? []), ...(config.bypassHosts ?? [])];
+    await ensureProxy(config.proxyRules, allBypassHosts, config.serverPort);
   }
 
   // 9. Mise pre-install
-  const miseVolume =
-    config.miseVolume ??
+  const miseInstallsPath =
+    config.miseInstallsPath ??
     (await ensureMiseRuntimes(
       config.projectRoot,
       agentImage,
@@ -247,7 +248,7 @@ export async function runTask(config: RunConfig, opts?: RunOptions): Promise<Tas
         shadowVolume,
         shadowDir,
         image: agentImage,
-        miseVolume,
+        miseInstallsPath,
       });
       if (!installResult.ok) {
         failWith(new Error(`Dependency install failed: ${installResult.error}`));
@@ -263,6 +264,9 @@ export async function runTask(config: RunConfig, opts?: RunOptions): Promise<Tas
   // 11. Spawn sandbox
   const env: Record<string, string> = { ...authEnv, ...containerConfig.envVars, ...config.extraEnv };
   if (config.promptUrl) env.PROMPT_URL = config.promptUrl;
+  const initCommands = ysaConfig.sandbox?.init_commands ?? [];
+  if (initCommands.length > 0) env.CONTAINER_INIT_COMMANDS = initCommands.join(" ; ");
+  if (config.bypassHosts?.length) env.BYPASS_HOSTS = config.bypassHosts.join(",");
 
   emitProgress("Starting agent...");
   let proc: Awaited<ReturnType<typeof spawnSandbox>>;
@@ -288,7 +292,7 @@ export async function runTask(config: RunConfig, opts?: RunOptions): Promise<Tas
       extraLabels: config.extraLabels,
       shadowDirs: config.shadowDirs,
       depCacheVolume,
-      miseVolume,
+      miseInstallsPath,
       containerMemory: config.containerMemory,
       containerCpus: config.containerCpus,
       containerPidsLimit: config.containerPidsLimit,

--- a/src/runtime/runner.ts
+++ b/src/runtime/runner.ts
@@ -209,7 +209,7 @@ export async function runTask(config: RunConfig, opts?: RunOptions): Promise<Tas
   // 8. Proxy auto-start
   if (config.networkPolicy === "strict") {
     emitProgress("Starting network proxy...");
-    await ensureProxy(config.proxyRules, undefined, config.serverPort);
+    await ensureProxy(config.proxyRules, adapter.bypassHosts, config.serverPort);
   }
 
   // 9. Mise pre-install
@@ -289,6 +289,9 @@ export async function runTask(config: RunConfig, opts?: RunOptions): Promise<Tas
       shadowDirs: config.shadowDirs,
       depCacheVolume,
       miseVolume,
+      containerMemory: config.containerMemory,
+      containerCpus: config.containerCpus,
+      containerPidsLimit: config.containerPidsLimit,
     });
   } catch (err) {
     failWith(err instanceof Error ? err : new Error(String(err)));

--- a/src/runtime/runner.ts
+++ b/src/runtime/runner.ts
@@ -185,15 +185,19 @@ export async function runTask(config: RunConfig, opts?: RunOptions): Promise<Tas
   // 7. Read .ysa.toml and resolve project image
   const ysaConfig = await readYsaConfig(config.projectRoot);
   const aptPackages = ysaConfig.sandbox?.packages ?? [];
+  const globalPackages = ysaConfig.sandbox?.global_packages ?? [];
   let agentImage = adapter.containerImage;
 
-  if (aptPackages.length > 0) {
+  if (aptPackages.length > 0 || globalPackages.length > 0) {
     const projImage = projectImageName(config.projectRoot, adapter.id);
-    const targetHash = Bun.hash([...aptPackages].sort().join(",")).toString(16);
+    const hashInput = globalPackages.length > 0
+      ? [...aptPackages].sort().join(",") + "|" + [...globalPackages].sort().join(",")
+      : [...aptPackages].sort().join(",");
+    const targetHash = Bun.hash(hashInput).toString(16);
     const currentHash = await getImagePackagesHash(projImage);
     if (currentHash !== targetHash) {
       emitProgress("Building project sandbox image...");
-      const built = await buildProjectImage(aptPackages, projImage, adapter.containerImage, adapter.packageManager, (line) => emitProgress(line));
+      const built = await buildProjectImage(aptPackages, projImage, adapter.containerImage, adapter.packageManager, globalPackages, (line) => emitProgress(line));
       if (!built.ok) {
         failWith(new Error(`Image build failed: ${built.error}`));
         return handle;

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,11 +35,12 @@ export interface RunConfig {
   shadowDirs?: string[]; // dirs to shadow with per-task volumes (default: ["node_modules"])
   depInstallCmd?: string; // command to install dependencies before starting the agent (e.g. "bun install")
   depsCacheKey?: string; // stable key for the deps shadow volume — same key reuses the volume and skips reinstall
-  miseVolume?: string;  // pre-populated mise-installs volume to mount (set at project settings save time)
+  miseInstallsPath?: string;  // host path to pre-populated mise-installs dir, bind-mounted :ro into task container
   worktreeFiles?: string[]; // untracked files to copy from project root into worktree
   extraEnv?: Record<string, string>; // extra env vars injected into the container (e.g. DASHBOARD_URL, ISSUE_ID)
   extraLabels?: Record<string, string>; // extra podman labels on the container (for filtering by stop/teardown)
   proxyRules?: import("./runtime/proxy").ScopedAllowRule[]; // per-task scoped proxy allow rules
+  bypassHosts?: string[]; // host or host:port — iptables ACCEPT + proxy bypass (skips all filtering)
   serverPort?: number; // host server port to bypass in proxy (e.g. dashboard port)
   allowCommit?: boolean; // whether the agent can commit to git (default: true)
   containerMemory?: string; // e.g. "8g"

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,9 @@ export interface RunConfig {
   proxyRules?: import("./runtime/proxy").ScopedAllowRule[]; // per-task scoped proxy allow rules
   serverPort?: number; // host server port to bypass in proxy (e.g. dashboard port)
   allowCommit?: boolean; // whether the agent can commit to git (default: true)
+  containerMemory?: string; // e.g. "8g"
+  containerCpus?: number;
+  containerPidsLimit?: number;
 }
 
 // Handle returned immediately by runTask() — container may still be running


### PR DESCRIPTION
## Summary

- **DeepSeek provider** — routes Claude Code's API protocol through `api.deepseek.com/anthropic`; uses `deepseek-v4-pro` by default, `deepseek-v4-flash` for sub-agents
- **`ysa key` command** — `ysa key set|check|delete <provider>` for securely storing provider API keys
- **`--provider` CLI flag** — `ysa run "..." --provider claude|deepseek|mistral` (was hardcoded to Claude)
- **`.ysa.toml` new fields** — `global_packages` (pip/npm/gem/cargo/go/bun global installs baked into project image) and `init_commands` (run inside container before agent starts)
- **`bypassHosts`** — new `RunConfig.bypassHosts` for direct TCP access to non-HTTP services (MongoDB, Redis, etc.), with SRV chain resolution; provider adapters can also declare `bypassHosts`
- **Configurable container resources** — `containerMemory`, `containerCpus`, `containerPidsLimit` in `RunConfig` (defaults: 4g / 2 / 512)
- **mise: volume → host bind-mount** — mise installs now stored at `~/.cache/ysa-agent/mise-installs/<hash>/` instead of a Podman named volume; more reliable on macOS
- **DNS fix (strict mode)** — OCI hook now uses `10.0.2.0/24` subnet for DNS rules instead of deriving gateway+1, which wasn't yet in the routing table at hook time
- **`HOME=/home/agent` fix** — explicitly set in containers and Containerfile; `passwd` cleanup prevents tools from computing `/`-based paths
- **`/repo.git` → `/tmp/repo.git`** inside container (consistent with `--read-only` + writable `/tmp`)

## Breaking changes

> Requires rebuilding sandbox images: `bun run build:images`

1. `RunConfig.miseVolume` → `miseInstallsPath` (host path, not a volume name) — existing `mise-installs-*` volumes are ignored
2. `MISE_VOLUME` env var → `MISE_INSTALL_PATH` in `sandbox-run.sh`
3. `/repo.git` → `/tmp/repo.git` inside the container — any in-container scripts referencing the old path will break
4. Sandbox images must be rebuilt (Containerfile changed: HOME env, passwd cleanup, new `/usr/local/mise-installs` dir)

## Test plan

- [ ] `ysa run "hello" --provider deepseek` works after `ysa key set deepseek`
- [ ] `ysa key set|check|delete mistral` stores and retrieves correctly
- [ ] `global_packages = ["pip:cowsay"]` in `.ysa.toml` installs into project image
- [ ] `init_commands = ["redis-server --daemonize yes"]` runs before agent
- [ ] `bypassHosts: ["cluster.mongodb.net"]` opens iptables rule in strict mode
- [ ] Mise runtimes pre-install and activate correctly (host dir, not volume)
- [ ] DNS resolves inside strict-mode container
- [ ] Container resource limits apply (`--memory`, `--cpus`, `--pids-limit`)